### PR TITLE
fix: Include edge case parsing provider-aws docs

### DIFF
--- a/data/reference/docs/typescript/provider-aws/r/api_gateway_usage_plan.json
+++ b/data/reference/docs/typescript/provider-aws/r/api_gateway_usage_plan.json
@@ -79,14 +79,14 @@
         {
           "name": "apiId",
           "type": "string",
-          "description": "",
+          "description": "(Required) - API Id of the associated API stage in a usage plan.",
           "required": true,
           "optional": false
         },
         {
           "name": "stage",
           "type": "string",
-          "description": "",
+          "description": "(Required) - API stage name of the associated API stage in a usage plan.",
           "required": true,
           "optional": false
         },
@@ -106,21 +106,21 @@
         {
           "name": "burstLimit",
           "type": "number",
-          "description": "",
+          "description": "(Optional) - The API request burst limit, the maximum rate limit over a time ranging from one to a few seconds, depending upon whether the underlying token bucket is at its full capacity.",
           "required": false,
           "optional": true
         },
         {
           "name": "path",
           "type": "string",
-          "description": "",
+          "description": "(Required) - Method to apply the throttle settings for. Specfiy the path and method, for example `/test/GET`.",
           "required": true,
           "optional": false
         },
         {
           "name": "rateLimit",
           "type": "number",
-          "description": "",
+          "description": "(Optional) - The API request steady-state rate limit.",
           "required": false,
           "optional": true
         }
@@ -133,21 +133,21 @@
         {
           "name": "limit",
           "type": "number",
-          "description": "",
+          "description": "(Optional) - Maximum number of requests that can be made in a given time period.",
           "required": true,
           "optional": false
         },
         {
           "name": "offset",
           "type": "number",
-          "description": "",
+          "description": "(Optional) - Number of requests subtracted from the given limit in the initial time period.",
           "required": false,
           "optional": true
         },
         {
           "name": "period",
           "type": "string",
-          "description": "",
+          "description": "(Optional) - Time period in which the limit applies. Valid values are \"DAY\", \"WEEK\" or \"MONTH\".",
           "required": true,
           "optional": false
         }
@@ -160,14 +160,14 @@
         {
           "name": "burstLimit",
           "type": "number",
-          "description": "",
+          "description": "(Optional) - The API request burst limit, the maximum rate limit over a time ranging from one to a few seconds, depending upon whether the underlying token bucket is at its full capacity.",
           "required": false,
           "optional": true
         },
         {
           "name": "rateLimit",
           "type": "number",
-          "description": "",
+          "description": "(Optional) - The API request steady-state rate limit.",
           "required": false,
           "optional": true
         }

--- a/data/reference/docs/typescript/provider-aws/r/db_instance_role_association.json
+++ b/data/reference/docs/typescript/provider-aws/r/db_instance_role_association.json
@@ -5,45 +5,55 @@
       "type": "string",
       "description": "(Required) DB Instance Identifier to associate with the IAM Role.",
       "required": true,
-      "optional": false,
-      "level": 0
+      "optional": false
     },
     {
       "name": "featureName",
       "type": "string",
       "description": "(Required) Name of the feature for association. This can be found in the AWS documentation relevant to the integration or a full list is available in the `SupportedFeatureNames` list returned by [AWS CLI rds describe-db-engine-versions](https://docs.aws.amazon.com/cli/latest/reference/rds/describe-db-engine-versions.html).",
       "required": true,
-      "optional": false,
-      "level": 0
+      "optional": false
+    },
+    {
+      "name": "id",
+      "type": "string",
+      "description": "",
+      "required": false,
+      "optional": true
     },
     {
       "name": "roleArn",
       "type": "string",
       "description": "(Required) Amazon Resource Name (ARN) of the IAM Role to associate with the DB Instance.",
       "required": true,
-      "optional": false,
-      "level": 0
+      "optional": false
+    },
+    {
+      "name": "timeouts",
+      "type": "block",
+      "description": "",
+      "required": false,
+      "optional": true
     }
   ],
   "blocks": [
     {
       "name": "timeouts",
+      "full_name": "Timeouts",
       "arguments": [
         {
           "name": "create",
           "type": "string",
           "description": "(Default `10m`) - `delete` - (Default `10m`)",
           "required": false,
-          "optional": true,
-          "level": 0
+          "optional": true
         },
         {
           "name": "delete",
           "type": "string",
           "description": "(Default `10m`)",
           "required": false,
-          "optional": true,
-          "level": 0
+          "optional": true
         }
       ]
     }

--- a/data/reference/docs/typescript/provider-aws/r/db_option_group.json
+++ b/data/reference/docs/typescript/provider-aws/r/db_option_group.json
@@ -1,150 +1,169 @@
 {
   "arguments": [
     {
-      "name": "name",
+      "name": "arn",
       "type": "string",
-      "description": "(Optional, Forces new resource) Name of the option group. If omitted, Terraform will assign a random, unique name. Must be lowercase, to match as it is stored in AWS.",
+      "description": "",
       "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "namePrefix",
-      "type": "string",
-      "description": "(Optional, Forces new resource) Creates a unique name beginning with the specified prefix. Conflicts with `name`. Must be lowercase, to match as it is stored in AWS.",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "skipDestroy",
-      "type": "bool",
-      "description": "(Optional) Set to true if you do not wish the option group to be deleted at destroy time, and instead just remove the option group from the Terraform state.",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "tags",
-      "type": "map",
-      "description": "(Optional) Map of tags to assign to the resource. If configured with a provider [`defaultTags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.",
-      "required": false,
-      "optional": true,
-      "level": 0
+      "optional": false
     },
     {
       "name": "engineName",
       "type": "string",
       "description": "(Required) Specifies the name of the engine that this option group should be associated with.",
       "required": true,
-      "optional": false,
-      "level": 0
+      "optional": false
+    },
+    {
+      "name": "id",
+      "type": "string",
+      "description": "",
+      "required": false,
+      "optional": true
     },
     {
       "name": "majorEngineVersion",
       "type": "string",
       "description": "(Required) Specifies the major version of the engine that this option group should be associated with.",
       "required": true,
-      "optional": false,
-      "level": 0
+      "optional": false
+    },
+    {
+      "name": "name",
+      "type": "string",
+      "description": "(Optional, Forces new resource) Name of the option group. If omitted, Terraform will assign a random, unique name. Must be lowercase, to match as it is stored in AWS.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "namePrefix",
+      "type": "string",
+      "description": "(Optional, Forces new resource) Creates a unique name beginning with the specified prefix. Conflicts with `name`. Must be lowercase, to match as it is stored in AWS.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "option",
+      "type": "block",
+      "description": "",
+      "required": false,
+      "optional": true
     },
     {
       "name": "optionGroupDescription",
       "type": "string",
       "description": "(Optional) Description of the option group. Defaults to \"Managed by Terraform\".",
       "required": false,
-      "optional": true,
-      "level": 0
+      "optional": true
     },
     {
-      "name": "option",
-      "type": "block",
-      "description": "(Optional) The options to apply. See [`option` Block](#option-block) below for more details.",
+      "name": "skipDestroy",
+      "type": "bool",
+      "description": "(Optional) Set to true if you do not wish the option group to be deleted at destroy time, and instead just remove the option group from the Terraform state.",
       "required": false,
-      "optional": true,
-      "level": 0
+      "optional": true
+    },
+    {
+      "name": "tags",
+      "type": "map",
+      "description": "(Optional) Map of tags to assign to the resource. If configured with a provider [`defaultTags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "tagsAll",
+      "type": "map",
+      "description": "",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "timeouts",
+      "type": "block",
+      "description": "",
+      "required": false,
+      "optional": true
     }
   ],
   "blocks": [
     {
       "name": "option",
+      "full_name": "Option",
       "arguments": [
-        {
-          "name": "version",
-          "type": "string",
-          "description": "(Optional) Version of the option (e.g., 13.1.0.0). Leaving out or removing `version` from your configuration does not remove or clear a version from the option in AWS. AWS may assign a default version. Not including `version` in your configuration means that the AWS provider will ignore a previously set value, a value set by AWS, and any version changes.",
-          "required": false,
-          "optional": true,
-          "level": 0
-        },
-        {
-          "name": "vpcSecurityGroupMemberships",
-          "type": "set",
-          "description": "(Optional) List of VPC Security Groups for which the option is enabled.",
-          "required": false,
-          "optional": true,
-          "level": 0
-        },
         {
           "name": "dbSecurityGroupMemberships",
           "type": "set",
           "description": "(Optional) List of DB Security Groups for which the option is enabled.",
           "required": false,
-          "optional": true,
-          "level": 0
+          "optional": true
         },
         {
           "name": "optionName",
           "type": "string",
           "description": "(Required) Name of the option (e.g., MEMCACHED).",
           "required": true,
-          "optional": false,
-          "level": 0
+          "optional": false
         },
         {
           "name": "port",
           "type": "number",
           "description": "(Optional) Port number when connecting to the option (e.g., 11211). Leaving out or removing `port` from your configuration does not remove or clear a port from the option in AWS. AWS may assign a default port. Not including `port` in your configuration means that the AWS provider will ignore a previously set value, a value set by AWS, and any port changes.",
           "required": false,
-          "optional": true,
-          "level": 0
+          "optional": true
+        },
+        {
+          "name": "version",
+          "type": "string",
+          "description": "(Optional) Version of the option (e.g., 13.1.0.0). Leaving out or removing `version` from your configuration does not remove or clear a version from the option in AWS. AWS may assign a default version. Not including `version` in your configuration means that the AWS provider will ignore a previously set value, a value set by AWS, and any version changes.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "vpcSecurityGroupMemberships",
+          "type": "set",
+          "description": "(Optional) List of VPC Security Groups for which the option is enabled.",
+          "required": false,
+          "optional": true
         },
         {
           "name": "optionSettings",
           "type": "block",
-          "description": "(Optional) The option settings to apply. See [`optionSettings` Block](#option_settings-block) below for more details.",
+          "description": "",
           "required": false,
-          "optional": true,
-          "level": 0
-        },
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "optionSettings",
+      "full_name": "OptionOptionSettings",
+      "arguments": [
         {
           "name": "name",
           "type": "string",
-          "description": "(Optional, Forces new resource) Name of the option group. If omitted, Terraform will assign a random, unique name. Must be lowercase, to match as it is stored in AWS.",
+          "description": "(Required) Name of the setting.",
           "required": true,
-          "optional": false,
-          "level": 0
+          "optional": false
         },
         {
           "name": "value",
           "type": "string",
           "description": "(Required) Value of the setting.",
           "required": true,
-          "optional": false,
-          "level": 0
+          "optional": false
         }
       ]
     },
     {
       "name": "timeouts",
+      "full_name": "Timeouts",
       "arguments": [
         {
           "name": "delete",
           "type": "string",
           "description": "(Default `15m`)",
           "required": false,
-          "optional": true,
-          "level": 0
+          "optional": true
         }
       ]
     }

--- a/data/reference/docs/typescript/provider-aws/r/ecr_repository.json
+++ b/data/reference/docs/typescript/provider-aws/r/ecr_repository.json
@@ -1,0 +1,136 @@
+{
+  "arguments": [
+    {
+      "name": "arn",
+      "type": "string",
+      "description": "",
+      "required": false,
+      "optional": false
+    },
+    {
+      "name": "encryptionConfiguration",
+      "type": "block",
+      "description": "",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "forceDelete",
+      "type": "bool",
+      "description": "(Optional) If `true`, will delete the repository even if it contains images.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "id",
+      "type": "string",
+      "description": "",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "imageScanningConfiguration",
+      "type": "block",
+      "description": "",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "imageTagMutability",
+      "type": "string",
+      "description": "(Optional) The tag mutability setting for the repository. Must be one of: `MUTABLE` or `IMMUTABLE`. Defaults to `MUTABLE`.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "name",
+      "type": "string",
+      "description": "(Required) Name of the repository.",
+      "required": true,
+      "optional": false
+    },
+    {
+      "name": "registryId",
+      "type": "string",
+      "description": "",
+      "required": false,
+      "optional": false
+    },
+    {
+      "name": "repositoryUrl",
+      "type": "string",
+      "description": "",
+      "required": false,
+      "optional": false
+    },
+    {
+      "name": "tags",
+      "type": "map",
+      "description": "(Optional) A map of tags to assign to the resource. If configured with a provider [`defaultTags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "tagsAll",
+      "type": "map",
+      "description": "",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "timeouts",
+      "type": "block",
+      "description": "",
+      "required": false,
+      "optional": true
+    }
+  ],
+  "blocks": [
+    {
+      "name": "encryptionConfiguration",
+      "full_name": "EncryptionConfiguration",
+      "arguments": [
+        {
+          "name": "encryptionType",
+          "type": "string",
+          "description": "(Optional) The encryption type to use for the repository. Valid values are `AES256` or `KMS`. Defaults to `AES256`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "kmsKey",
+          "type": "string",
+          "description": "(Optional) The ARN of the KMS key to use when `encryptionType` is `KMS`. If not specified, uses the default AWS managed key for ECR.",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "imageScanningConfiguration",
+      "full_name": "ImageScanningConfiguration",
+      "arguments": [
+        {
+          "name": "scanOnPush",
+          "type": "bool",
+          "description": "(Required) Indicates whether images are scanned after being pushed to the repository (true) or not scanned (false).",
+          "required": true,
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "timeouts",
+      "full_name": "Timeouts",
+      "arguments": [
+        {
+          "name": "delete",
+          "type": "string",
+          "description": "(Default `20m`)",
+          "required": false,
+          "optional": true
+        }
+      ]
+    }
+  ]
+}

--- a/data/reference/docs/typescript/provider-aws/r/ecr_repository_creation_template.json
+++ b/data/reference/docs/typescript/provider-aws/r/ecr_repository_creation_template.json
@@ -1,0 +1,103 @@
+{
+  "arguments": [
+    {
+      "name": "appliedFor",
+      "type": "set",
+      "description": "(Required) Which features this template applies to. Must contain one or more of `PULL_THROUGH_CACHE` or `REPLICATION`.",
+      "required": true,
+      "optional": false
+    },
+    {
+      "name": "customRoleArn",
+      "type": "string",
+      "description": "(Optional) A custom IAM role to use for repository creation. Required if using repository tags or KMS encryption.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "description",
+      "type": "string",
+      "description": "(Optional) The description for this template.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "encryptionConfiguration",
+      "type": "block",
+      "description": "",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "id",
+      "type": "string",
+      "description": "",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "imageTagMutability",
+      "type": "string",
+      "description": "(Optional) The tag mutability setting for any created repositories. Must be one of: `MUTABLE` or `IMMUTABLE`. Defaults to `MUTABLE`.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "lifecyclePolicy",
+      "type": "string",
+      "description": "(Optional) The lifecycle policy document to apply to any created repositories. See more details about [Policy Parameters](http://docs.aws.amazon.com/AmazonECR/latest/userguide/LifecyclePolicies.html#lifecycle_policy_parameters) in the official AWS docs. Consider using the [`aws_ecr_lifecycle_policy_document` data_source](/docs/providers/aws/d/ecr_lifecycle_policy_document.html) to generate/manage the JSON document used for the `lifecyclePolicy` argument.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "prefix",
+      "type": "string",
+      "description": "(Required, Forces new resource) The repository name prefix to match against. Use `ROOT` to match any prefix that doesn't explicitly match another template.",
+      "required": true,
+      "optional": false
+    },
+    {
+      "name": "registryId",
+      "type": "string",
+      "description": "",
+      "required": false,
+      "optional": false
+    },
+    {
+      "name": "repositoryPolicy",
+      "type": "string",
+      "description": "(Optional) The registry policy document to apply to any created repositories. This is a JSON formatted string. For more information about building IAM policy documents with Terraform, see the [AWS IAM Policy Document Guide](https://learn.hashicorp.com/terraform/aws/iam-policy).",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "resourceTags",
+      "type": "map",
+      "description": "(Optional) A map of tags to assign to any created repositories.",
+      "required": false,
+      "optional": true
+    }
+  ],
+  "blocks": [
+    {
+      "name": "encryptionConfiguration",
+      "full_name": "EncryptionConfiguration",
+      "arguments": [
+        {
+          "name": "encryptionType",
+          "type": "string",
+          "description": "(Optional) The encryption type to use for any created repositories. Valid values are `AES256` or `KMS`. Defaults to `AES256`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "kmsKey",
+          "type": "string",
+          "description": "(Optional) The ARN of the KMS key to use when `encryptionType` is `KMS`. If not specified, uses the default AWS managed key for ECR.",
+          "required": false,
+          "optional": true
+        }
+      ]
+    }
+  ]
+}

--- a/data/reference/docs/typescript/provider-aws/r/ecr_repository_policy.json
+++ b/data/reference/docs/typescript/provider-aws/r/ecr_repository_policy.json
@@ -1,0 +1,32 @@
+{
+  "arguments": [
+    {
+      "name": "id",
+      "type": "string",
+      "description": "",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "policy",
+      "type": "string",
+      "description": "(Required) The policy document. This is a JSON formatted string. For more information about building IAM policy documents with Terraform, see the [AWS IAM Policy Document Guide](https://learn.hashicorp.com/terraform/aws/iam-policy)",
+      "required": true,
+      "optional": false
+    },
+    {
+      "name": "registryId",
+      "type": "string",
+      "description": "",
+      "required": false,
+      "optional": false
+    },
+    {
+      "name": "repository",
+      "type": "string",
+      "description": "(Required) Name of the repository to apply the policy.",
+      "required": true,
+      "optional": false
+    }
+  ]
+}

--- a/data/reference/docs/typescript/provider-aws/r/ecrpublic_repository.json
+++ b/data/reference/docs/typescript/provider-aws/r/ecrpublic_repository.json
@@ -1,0 +1,137 @@
+{
+  "arguments": [
+    {
+      "name": "arn",
+      "type": "string",
+      "description": "",
+      "required": false,
+      "optional": false
+    },
+    {
+      "name": "catalogData",
+      "type": "block",
+      "description": "",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "forceDestroy",
+      "type": "bool",
+      "description": "",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "id",
+      "type": "string",
+      "description": "",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "registryId",
+      "type": "string",
+      "description": "",
+      "required": false,
+      "optional": false
+    },
+    {
+      "name": "repositoryName",
+      "type": "string",
+      "description": "(Required) Name of the repository.",
+      "required": true,
+      "optional": false
+    },
+    {
+      "name": "repositoryUri",
+      "type": "string",
+      "description": "",
+      "required": false,
+      "optional": false
+    },
+    {
+      "name": "tags",
+      "type": "map",
+      "description": "(Optional) Key-value mapping of resource tags. If configured with a provider [`defaultTags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "tagsAll",
+      "type": "map",
+      "description": "",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "timeouts",
+      "type": "block",
+      "description": "",
+      "required": false,
+      "optional": true
+    }
+  ],
+  "blocks": [
+    {
+      "name": "catalogData",
+      "full_name": "CatalogData",
+      "arguments": [
+        {
+          "name": "aboutText",
+          "type": "string",
+          "description": "(Optional) A detailed description of the contents of the repository. It is publicly visible in the Amazon ECR Public Gallery. The text must be in markdown format.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "architectures",
+          "type": "set",
+          "description": "(Optional) The system architecture that the images in the repository are compatible with. On the Amazon ECR Public Gallery, the following supported architectures will appear as badges on the repository and are used as search filters: `ARM`, `ARM 64`, `x86`, `x86-64`",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "description",
+          "type": "string",
+          "description": "(Optional) A short description of the contents of the repository. This text appears in both the image details and also when searching for repositories on the Amazon ECR Public Gallery.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "logoImageBlob",
+          "type": "string",
+          "description": "(Optional) The base64-encoded repository logo payload. (Only visible for verified accounts) Note that drift detection is disabled for this attribute.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "operatingSystems",
+          "type": "set",
+          "description": "(Optional) The operating systems that the images in the repository are compatible with. On the Amazon ECR Public Gallery, the following supported operating systems will appear as badges on the repository and are used as search filters: `Linux`, `Windows`",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "usageText",
+          "type": "string",
+          "description": "(Optional) Detailed information on how to use the contents of the repository. It is publicly visible in the Amazon ECR Public Gallery. The usage text provides context, support information, and additional usage details for users of the repository. The text must be in markdown format.",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "timeouts",
+      "full_name": "Timeouts",
+      "arguments": [
+        {
+          "name": "delete",
+          "type": "string",
+          "description": "(Default `20m`)",
+          "required": false,
+          "optional": true
+        }
+      ]
+    }
+  ]
+}

--- a/data/reference/docs/typescript/provider-aws/r/ecrpublic_repository_policy.json
+++ b/data/reference/docs/typescript/provider-aws/r/ecrpublic_repository_policy.json
@@ -1,0 +1,32 @@
+{
+  "arguments": [
+    {
+      "name": "id",
+      "type": "string",
+      "description": "",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "policy",
+      "type": "string",
+      "description": "(Required) The policy document. This is a JSON formatted string. For more information about building IAM policy documents with Terraform, see the [AWS IAM Policy Document Guide](https://learn.hashicorp.com/terraform/aws/iam-policy)",
+      "required": true,
+      "optional": false
+    },
+    {
+      "name": "registryId",
+      "type": "string",
+      "description": "",
+      "required": false,
+      "optional": false
+    },
+    {
+      "name": "repositoryName",
+      "type": "string",
+      "description": "(Required) Name of the repository to apply the policy.",
+      "required": true,
+      "optional": false
+    }
+  ]
+}

--- a/data/reference/docs/typescript/provider-aws/r/imagebuilder_image.json
+++ b/data/reference/docs/typescript/provider-aws/r/imagebuilder_image.json
@@ -1,0 +1,273 @@
+{
+  "arguments": [
+    {
+      "name": "arn",
+      "type": "string",
+      "description": "",
+      "required": false,
+      "optional": false
+    },
+    {
+      "name": "containerRecipeArn",
+      "type": "string",
+      "description": "(Optional) - Amazon Resource Name (ARN) of the container recipe.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "dateCreated",
+      "type": "string",
+      "description": "",
+      "required": false,
+      "optional": false
+    },
+    {
+      "name": "distributionConfigurationArn",
+      "type": "string",
+      "description": "(Optional) Amazon Resource Name (ARN) of the Image Builder Distribution Configuration.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "enhancedImageMetadataEnabled",
+      "type": "bool",
+      "description": "(Optional) Whether additional information about the image being created is collected. Defaults to `true`.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "executionRole",
+      "type": "string",
+      "description": "(Optional) Amazon Resource Name (ARN) of the service-linked role to be used by Image Builder to [execute workflows](https://docs.aws.amazon.com/imagebuilder/latest/userguide/manage-image-workflows.html).",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "id",
+      "type": "string",
+      "description": "",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "imageRecipeArn",
+      "type": "string",
+      "description": "(Optional) Amazon Resource Name (ARN) of the image recipe.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "imageScanningConfiguration",
+      "type": "block",
+      "description": "",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "imageTestsConfiguration",
+      "type": "block",
+      "description": "",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "infrastructureConfigurationArn",
+      "type": "string",
+      "description": "(Required) Amazon Resource Name (ARN) of the Image Builder Infrastructure Configuration.",
+      "required": true,
+      "optional": false
+    },
+    {
+      "name": "name",
+      "type": "string",
+      "description": "(Required) The name of the Workflow parameter.",
+      "required": false,
+      "optional": false
+    },
+    {
+      "name": "osVersion",
+      "type": "string",
+      "description": "",
+      "required": false,
+      "optional": false
+    },
+    {
+      "name": "outputResources",
+      "type": "list",
+      "description": "",
+      "required": false,
+      "optional": false
+    },
+    {
+      "name": "platform",
+      "type": "string",
+      "description": "",
+      "required": false,
+      "optional": false
+    },
+    {
+      "name": "tags",
+      "type": "map",
+      "description": "(Optional) Key-value map of resource tags for the Image Builder Image. If configured with a provider [`defaultTags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "tagsAll",
+      "type": "map",
+      "description": "",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "timeouts",
+      "type": "block",
+      "description": "",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "version",
+      "type": "string",
+      "description": "",
+      "required": false,
+      "optional": false
+    },
+    {
+      "name": "workflow",
+      "type": "block",
+      "description": "",
+      "required": false,
+      "optional": true
+    }
+  ],
+  "blocks": [
+    {
+      "name": "imageScanningConfiguration",
+      "full_name": "ImageScanningConfiguration",
+      "arguments": [
+        {
+          "name": "imageScanningEnabled",
+          "type": "bool",
+          "description": "(Optional) Indicates whether Image Builder keeps a snapshot of the vulnerability scans that Amazon Inspector runs against the build instance when you create a new image. Defaults to `false`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "ecrConfiguration",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "ecrConfiguration",
+      "full_name": "ImageScanningConfigurationEcrConfiguration",
+      "arguments": [
+        {
+          "name": "containerTags",
+          "type": "set",
+          "description": "(Optional) Set of tags for Image Builder to apply to the output container image that that Amazon Inspector scans.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "repositoryName",
+          "type": "string",
+          "description": "(Optional) The name of the container repository that Amazon Inspector scans to identify findings for your container images.",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "imageTestsConfiguration",
+      "full_name": "ImageTestsConfiguration",
+      "arguments": [
+        {
+          "name": "imageTestsEnabled",
+          "type": "bool",
+          "description": "(Optional) Whether image tests are enabled. Defaults to `true`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "timeoutMinutes",
+          "type": "number",
+          "description": "(Optional) Number of minutes before image tests time out. Valid values are between `60` and `1440`. Defaults to `720`.",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "timeouts",
+      "full_name": "Timeouts",
+      "arguments": [
+        {
+          "name": "create",
+          "type": "string",
+          "description": "(Default `60m`)",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "workflow",
+      "full_name": "Workflow",
+      "arguments": [
+        {
+          "name": "onFailure",
+          "type": "string",
+          "description": "(Optional) The action to take if the workflow fails. Must be one of `CONTINUE` or `ABORT`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "parallelGroup",
+          "type": "string",
+          "description": "(Optional) The parallel group in which to run a test Workflow.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "workflowArn",
+          "type": "string",
+          "description": "(Required) Amazon Resource Name (ARN) of the Image Builder Workflow.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "parameter",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "parameter",
+      "full_name": "WorkflowParameter",
+      "arguments": [
+        {
+          "name": "name",
+          "type": "string",
+          "description": "(Required) The name of the Workflow parameter.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "value",
+          "type": "string",
+          "description": "(Required) The value of the Workflow parameter.",
+          "required": true,
+          "optional": false
+        }
+      ]
+    }
+  ]
+}

--- a/data/reference/docs/typescript/provider-aws/r/kinesis_firehose_delivery_stream.json
+++ b/data/reference/docs/typescript/provider-aws/r/kinesis_firehose_delivery_stream.json
@@ -1,0 +1,3622 @@
+{
+  "arguments": [
+    {
+      "name": "arn",
+      "type": "string",
+      "description": "",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "destination",
+      "type": "string",
+      "description": "(Required) This is the destination to where the data is delivered. The only options are `s3` (Deprecated, use `extended_s3` instead), `extended_s3`, `redshift`, `elasticsearch`, `splunk`, `httpEndpoint`, `opensearch`, `opensearchserverless` and `snowflake`.",
+      "required": true,
+      "optional": false
+    },
+    {
+      "name": "destinationId",
+      "type": "string",
+      "description": "",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "elasticsearchConfiguration",
+      "type": "block",
+      "description": "",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "extendedS3Configuration",
+      "type": "block",
+      "description": "",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "httpEndpointConfiguration",
+      "type": "block",
+      "description": "",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "icebergConfiguration",
+      "type": "block",
+      "description": "",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "id",
+      "type": "string",
+      "description": "",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "kinesisSourceConfiguration",
+      "type": "block",
+      "description": "",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "mskSourceConfiguration",
+      "type": "block",
+      "description": "",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "name",
+      "type": "string",
+      "description": "(Required) A name to identify the stream. This is unique to the AWS account and region the Stream is created in. When using for WAF logging, name must be prefixed with `aws-waf-logs-`. See [AWS Documentation](https://docs.aws.amazon.com/waf/latest/developerguide/waf-policies.html#waf-policies-logging-config) for more details.",
+      "required": true,
+      "optional": false
+    },
+    {
+      "name": "opensearchConfiguration",
+      "type": "block",
+      "description": "",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "opensearchserverlessConfiguration",
+      "type": "block",
+      "description": "",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "redshiftConfiguration",
+      "type": "block",
+      "description": "",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "serverSideEncryption",
+      "type": "block",
+      "description": "",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "snowflakeConfiguration",
+      "type": "block",
+      "description": "",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "splunkConfiguration",
+      "type": "block",
+      "description": "",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "tags",
+      "type": "map",
+      "description": "(Optional) A map of tags to assign to the resource. If configured with a provider [`defaultTags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "tagsAll",
+      "type": "map",
+      "description": "",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "timeouts",
+      "type": "block",
+      "description": "",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "versionId",
+      "type": "string",
+      "description": "(Optional) Specifies the table version for the output data schema. Defaults to `LATEST`.",
+      "required": false,
+      "optional": true
+    }
+  ],
+  "blocks": [
+    {
+      "name": "elasticsearchConfiguration",
+      "full_name": "ElasticsearchConfiguration",
+      "arguments": [
+        {
+          "name": "bufferingInterval",
+          "type": "number",
+          "description": "(Optional) Buffer incoming data for the specified period of time, in seconds between 0 to 900, before delivering it to the destination.  The default value is 300s.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "bufferingSize",
+          "type": "number",
+          "description": "(Optional) Buffer incoming data to the specified size, in MBs between 1 to 100, before delivering it to the destination.  The default value is 5MB.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "clusterEndpoint",
+          "type": "string",
+          "description": "(Optional) The endpoint to use when communicating with the cluster. Conflicts with `domainArn`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "domainArn",
+          "type": "string",
+          "description": "(Optional) The ARN of the Amazon ES domain.  The pattern needs to be `arn:.*`.  Conflicts with `clusterEndpoint`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "indexName",
+          "type": "string",
+          "description": "(Required) The Elasticsearch index name.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "indexRotationPeriod",
+          "type": "string",
+          "description": "(Optional) The Elasticsearch index rotation period.  Index rotation appends a timestamp to the IndexName to facilitate expiration of old data.  Valid values are `NoRotation`, `OneHour`, `OneDay`, `OneWeek`, and `OneMonth`.  The default value is `OneDay`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "retryDuration",
+          "type": "number",
+          "description": "(Optional) After an initial failure to deliver to Amazon Elasticsearch, the total amount of time, in seconds between 0 to 7200, during which Firehose re-attempts delivery (including the first attempt).  After this time has elapsed, the failed documents are written to Amazon S3.  The default value is 300s.  There will be no retry if the value is 0.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "roleArn",
+          "type": "string",
+          "description": "(Required) The ARN of the IAM role to be assumed by Firehose for calling the Amazon ES Configuration API and for indexing documents.  The IAM role must have permission for `DescribeElasticsearchDomain`, `DescribeElasticsearchDomains`, and `DescribeElasticsearchDomainConfig`.  The pattern needs to be `arn:.*`.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "s3BackupMode",
+          "type": "string",
+          "description": "(Optional) Defines how documents should be delivered to Amazon S3.  Valid values are `FailedDocumentsOnly` and `AllDocuments`.  Default value is `FailedDocumentsOnly`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "typeName",
+          "type": "string",
+          "description": "(Optional) The Elasticsearch type name with maximum length of 100 characters.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "s3Configuration",
+          "type": "block",
+          "description": "",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "vpcConfig",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "cloudwatchLoggingOptions",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "processingConfiguration",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "cloudwatchLoggingOptions",
+      "full_name": "ElasticsearchConfigurationCloudwatchLoggingOptions",
+      "arguments": [
+        {
+          "name": "enabled",
+          "type": "bool",
+          "description": "(Optional) Enables or disables the logging. Defaults to `false`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "logGroupName",
+          "type": "string",
+          "description": "(Optional) The CloudWatch group name for logging. This value is required if `enabled` is true.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "logStreamName",
+          "type": "string",
+          "description": "(Optional) The CloudWatch log stream name for logging. This value is required if `enabled` is true.",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "processingConfiguration",
+      "full_name": "ElasticsearchConfigurationProcessingConfiguration",
+      "arguments": [
+        {
+          "name": "enabled",
+          "type": "bool",
+          "description": "(Optional) Enables or disables data processing.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "processors",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "processors",
+      "full_name": "ElasticsearchConfigurationProcessingConfigurationProcessors",
+      "arguments": [
+        {
+          "name": "type",
+          "type": "string",
+          "description": "(Required) The type of processor. Valid Values: `RecordDeAggregation`, `Lambda`, `MetadataExtraction`, `AppendDelimiterToRecord`, `Decompression`, `CloudWatchLogProcessing`. Validation is done against [AWS SDK constants](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/firehose/types#ProcessorType); so values not explicitly listed may also work.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "parameters",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "parameters",
+      "full_name": "ElasticsearchConfigurationProcessingConfigurationProcessorsParameters",
+      "arguments": [
+        {
+          "name": "parameterName",
+          "type": "string",
+          "description": "(Required) Parameter name. Valid Values: `LambdaArn`, `NumberOfRetries`, `MetadataExtractionQuery`, `JsonParsingEngine`, `RoleArn`, `BufferSizeInMBs`, `BufferIntervalInSeconds`, `SubRecordType`, `Delimiter`, `CompressionFormat`, `DataMessageExtraction`. Validation is done against [AWS SDK constants](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/firehose/types#ProcessorParameterName); so values not explicitly listed may also work.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "parameterValue",
+          "type": "string",
+          "description": "(Required) Parameter value. Must be between 1 and 512 length (inclusive). When providing a Lambda ARN, you should specify the resource version as well.",
+          "required": true,
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "s3Configuration",
+      "full_name": "ElasticsearchConfigurationS3Configuration",
+      "arguments": [
+        {
+          "name": "bucketArn",
+          "type": "string",
+          "description": "(Required) The ARN of the S3 bucket",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "bufferingInterval",
+          "type": "number",
+          "description": "(Optional) Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. The default value is 300 (5 minutes).",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "bufferingSize",
+          "type": "number",
+          "description": "(Optional) Buffer incoming data to the specified size, in MBs, before delivering it to the destination. The default value is 5.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "compressionFormat",
+          "type": "string",
+          "description": "(Optional) The compression format. If no value is specified, the default is `UNCOMPRESSED`. Other supported values are `GZIP`, `ZIP`, `Snappy`, \u0026 `HADOOP_SNAPPY`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "errorOutputPrefix",
+          "type": "string",
+          "description": "(Optional) Prefix added to failed records before writing them to S3. Not currently supported for `redshift` destination. This prefix appears immediately following the bucket name. For information about how to specify this prefix, see [Custom Prefixes for Amazon S3 Objects](https://docs.aws.amazon.com/firehose/latest/dev/s3-prefixes.html).",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "kmsKeyArn",
+          "type": "string",
+          "description": "(Optional) Specifies the KMS key ARN the stream will use to encrypt data. If not set, no encryption will be used.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "prefix",
+          "type": "string",
+          "description": "(Optional) The \"YYYY/MM/DD/HH\" time format prefix is automatically used for delivered S3 files. You can specify an extra prefix to be added in front of the time format prefix. Note that if the prefix ends with a slash, it appears as a folder in the S3 bucket",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "roleArn",
+          "type": "string",
+          "description": "(Required) Kinesis Data Firehose uses this IAM role for all the permissions that the delivery stream needs. The pattern needs to be `arn:.*`.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "cloudwatchLoggingOptions",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "cloudwatchLoggingOptions",
+      "full_name": "ElasticsearchConfigurationS3ConfigurationCloudwatchLoggingOptions",
+      "arguments": [
+        {
+          "name": "enabled",
+          "type": "bool",
+          "description": "(Optional) Enables or disables the logging. Defaults to `false`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "logGroupName",
+          "type": "string",
+          "description": "(Optional) The CloudWatch group name for logging. This value is required if `enabled` is true.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "logStreamName",
+          "type": "string",
+          "description": "(Optional) The CloudWatch log stream name for logging. This value is required if `enabled` is true.",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "vpcConfig",
+      "full_name": "ElasticsearchConfigurationVpcConfig",
+      "arguments": [
+        {
+          "name": "roleArn",
+          "type": "string",
+          "description": "(Required) The ARN of the IAM role to be assumed by Firehose for calling the Amazon EC2 configuration API and for creating network interfaces. Make sure role has necessary [IAM permissions](https://docs.aws.amazon.com/firehose/latest/dev/controlling-access.html#using-iam-es-vpc)",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "securityGroupIds",
+          "type": "set",
+          "description": "(Required) A list of security group IDs to associate with Kinesis Firehose.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "subnetIds",
+          "type": "set",
+          "description": "(Required) A list of subnet IDs to associate with Kinesis Firehose.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "vpcId",
+          "type": "string",
+          "description": "",
+          "required": false,
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "extendedS3Configuration",
+      "full_name": "ExtendedS3Configuration",
+      "arguments": [
+        {
+          "name": "bucketArn",
+          "type": "string",
+          "description": "(Required) The ARN of the S3 bucket",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "bufferingInterval",
+          "type": "number",
+          "description": "(Optional) Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. The default value is 300.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "bufferingSize",
+          "type": "number",
+          "description": "(Optional) Buffer incoming data to the specified size, in MBs, before delivering it to the destination. The default value is 5.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "compressionFormat",
+          "type": "string",
+          "description": "(Optional) The compression format. If no value is specified, the default is `UNCOMPRESSED`. Other supported values are `GZIP`, `ZIP`, `Snappy`, \u0026 `HADOOP_SNAPPY`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "customTimeZone",
+          "type": "string",
+          "description": "(Optional) The time zone you prefer. Valid values are `UTC` or a non-3-letter IANA time zones (for example, `America/Los_Angeles`). Default value is `UTC`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "errorOutputPrefix",
+          "type": "string",
+          "description": "(Optional) Prefix added to failed records before writing them to S3. Not currently supported for `redshift` destination. This prefix appears immediately following the bucket name. For information about how to specify this prefix, see [Custom Prefixes for Amazon S3 Objects](https://docs.aws.amazon.com/firehose/latest/dev/s3-prefixes.html).",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "fileExtension",
+          "type": "string",
+          "description": "(Optional) The file extension to override the default file extension (for example, `.json`).",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "kmsKeyArn",
+          "type": "string",
+          "description": "(Optional) Specifies the KMS key ARN the stream will use to encrypt data. If not set, no encryption will be used.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "prefix",
+          "type": "string",
+          "description": "(Optional) The \"YYYY/MM/DD/HH\" time format prefix is automatically used for delivered S3 files. You can specify an extra prefix to be added in front of the time format prefix. Note that if the prefix ends with a slash, it appears as a folder in the S3 bucket",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "roleArn",
+          "type": "string",
+          "description": "(Required) The ARN of the IAM role to be assumed by Firehose for calling the Amazon ES Configuration API and for indexing documents.  The IAM role must have permission for `DescribeElasticsearchDomain`, `DescribeElasticsearchDomains`, and `DescribeElasticsearchDomainConfig`.  The pattern needs to be `arn:.*`.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "s3BackupMode",
+          "type": "string",
+          "description": "(Optional) Defines how documents should be delivered to Amazon S3.  Valid values are `FailedDocumentsOnly` and `AllDocuments`.  Default value is `FailedDocumentsOnly`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "dataFormatConversionConfiguration",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "dynamicPartitioningConfiguration",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "processingConfiguration",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "s3BackupConfiguration",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "cloudwatchLoggingOptions",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "cloudwatchLoggingOptions",
+      "full_name": "ExtendedS3ConfigurationCloudwatchLoggingOptions",
+      "arguments": [
+        {
+          "name": "enabled",
+          "type": "bool",
+          "description": "(Optional) Enables or disables the logging. Defaults to `false`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "logGroupName",
+          "type": "string",
+          "description": "(Optional) The CloudWatch group name for logging. This value is required if `enabled` is true.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "logStreamName",
+          "type": "string",
+          "description": "(Optional) The CloudWatch log stream name for logging. This value is required if `enabled` is true.",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "dataFormatConversionConfiguration",
+      "full_name": "ExtendedS3ConfigurationDataFormatConversionConfiguration",
+      "arguments": [
+        {
+          "name": "enabled",
+          "type": "bool",
+          "description": "(Optional) Defaults to `true`. Set it to `false` if you want to disable format conversion while preserving the configuration details.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "inputFormatConfiguration",
+          "type": "block",
+          "description": "",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "outputFormatConfiguration",
+          "type": "block",
+          "description": "",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "schemaConfiguration",
+          "type": "block",
+          "description": "",
+          "required": true,
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "inputFormatConfiguration",
+      "full_name": "ExtendedS3ConfigurationDataFormatConversionConfigurationInputFormatConfiguration",
+      "arguments": [
+        {
+          "name": "deserializer",
+          "type": "block",
+          "description": "",
+          "required": true,
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "deserializer",
+      "full_name": "ExtendedS3ConfigurationDataFormatConversionConfigurationInputFormatConfigurationDeserializer",
+      "arguments": [
+        {
+          "name": "hiveJsonSerDe",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "openXJsonSerDe",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "hiveJsonSerDe",
+      "full_name": "ExtendedS3ConfigurationDataFormatConversionConfigurationInputFormatConfigurationDeserializerHiveJsonSerDe",
+      "arguments": [
+        {
+          "name": "timestampFormats",
+          "type": "list",
+          "description": "(Optional) A list of how you want Kinesis Data Firehose to parse the date and time stamps that may be present in your input data JSON. To specify these format strings, follow the pattern syntax of JodaTime's DateTimeFormat format strings. For more information, see [Class DateTimeFormat](https://www.joda.org/joda-time/apidocs/org/joda/time/format/DateTimeFormat.html). You can also use the special value millis to parse time stamps in epoch milliseconds. If you don't specify a format, Kinesis Data Firehose uses java.sql.Timestamp::valueOf by default.",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "openXJsonSerDe",
+      "full_name": "ExtendedS3ConfigurationDataFormatConversionConfigurationInputFormatConfigurationDeserializerOpenXJsonSerDe",
+      "arguments": [
+        {
+          "name": "caseInsensitive",
+          "type": "bool",
+          "description": "(Optional) When set to true, which is the default, Kinesis Data Firehose converts JSON keys to lowercase before deserializing them.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "columnToJsonKeyMappings",
+          "type": "map",
+          "description": "(Optional) A map of column names to JSON keys that aren't identical to the column names. This is useful when the JSON contains keys that are Hive keywords. For example, timestamp is a Hive keyword. If you have a JSON key named timestamp, set this parameter to `{ ts = \"timestamp\" }` to map this key to a column named ts.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "convertDotsInJsonKeysToUnderscores",
+          "type": "bool",
+          "description": "(Optional) When set to `true`, specifies that the names of the keys include dots and that you want Kinesis Data Firehose to replace them with underscores. This is useful because Apache Hive does not allow dots in column names. For example, if the JSON contains a key whose name is \"a.b\", you can define the column name to be \"a_b\" when using this option. Defaults to `false`.",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "outputFormatConfiguration",
+      "full_name": "ExtendedS3ConfigurationDataFormatConversionConfigurationOutputFormatConfiguration",
+      "arguments": [
+        {
+          "name": "serializer",
+          "type": "block",
+          "description": "",
+          "required": true,
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "serializer",
+      "full_name": "ExtendedS3ConfigurationDataFormatConversionConfigurationOutputFormatConfigurationSerializer",
+      "arguments": [
+        {
+          "name": "orcSerDe",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "parquetSerDe",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "orcSerDe",
+      "full_name": "ExtendedS3ConfigurationDataFormatConversionConfigurationOutputFormatConfigurationSerializerOrcSerDe",
+      "arguments": [
+        {
+          "name": "blockSizeBytes",
+          "type": "number",
+          "description": "(Optional) The Hadoop Distributed File System (HDFS) block size. This is useful if you intend to copy the data from Amazon S3 to HDFS before querying. The default is 256 MiB and the minimum is 64 MiB. Kinesis Data Firehose uses this value for padding calculations.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "bloomFilterColumns",
+          "type": "list",
+          "description": "(Optional) A list of column names for which you want Kinesis Data Firehose to create bloom filters.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "bloomFilterFalsePositiveProbability",
+          "type": "number",
+          "description": "(Optional) The Bloom filter false positive probability (FPP). The lower the FPP, the bigger the Bloom filter. The default value is `0.05`, the minimum is `0`, and the maximum is `1`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "compression",
+          "type": "string",
+          "description": "(Optional) The compression code to use over data blocks. The default is `SNAPPY`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "dictionaryKeyThreshold",
+          "type": "number",
+          "description": "(Optional) A float that represents the fraction of the total number of non-null rows. To turn off dictionary encoding, set this fraction to a number that is less than the number of distinct keys in a dictionary. To always use dictionary encoding, set this threshold to `1`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "enablePadding",
+          "type": "bool",
+          "description": "(Optional) Set this to `true` to indicate that you want stripes to be padded to the HDFS block boundaries. This is useful if you intend to copy the data from Amazon S3 to HDFS before querying. The default is `false`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "formatVersion",
+          "type": "string",
+          "description": "(Optional) The version of the file to write. The possible values are `V0_11` and `V0_12`. The default is `V0_12`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "paddingTolerance",
+          "type": "number",
+          "description": "(Optional) A float between 0 and 1 that defines the tolerance for block padding as a decimal fraction of stripe size. The default value is `0.05`, which means 5 percent of stripe size. For the default values of 64 MiB ORC stripes and 256 MiB HDFS blocks, the default block padding tolerance of 5 percent reserves a maximum of 3.2 MiB for padding within the 256 MiB block. In such a case, if the available size within the block is more than 3.2 MiB, a new, smaller stripe is inserted to fit within that space. This ensures that no stripe crosses block boundaries and causes remote reads within a node-local task. Kinesis Data Firehose ignores this parameter when `enablePadding` is `false`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "rowIndexStride",
+          "type": "number",
+          "description": "(Optional) The number of rows between index entries. The default is `10000` and the minimum is `1000`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "stripeSizeBytes",
+          "type": "number",
+          "description": "(Optional) The number of bytes in each stripe. The default is 64 MiB and the minimum is 8 MiB.",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "parquetSerDe",
+      "full_name": "ExtendedS3ConfigurationDataFormatConversionConfigurationOutputFormatConfigurationSerializerParquetSerDe",
+      "arguments": [
+        {
+          "name": "blockSizeBytes",
+          "type": "number",
+          "description": "(Optional) The Hadoop Distributed File System (HDFS) block size. This is useful if you intend to copy the data from Amazon S3 to HDFS before querying. The default is 256 MiB and the minimum is 64 MiB. Kinesis Data Firehose uses this value for padding calculations.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "compression",
+          "type": "string",
+          "description": "(Optional) The compression code to use over data blocks. The possible values are `UNCOMPRESSED`, `SNAPPY`, and `GZIP`, with the default being `SNAPPY`. Use `SNAPPY` for higher decompression speed. Use `GZIP` if the compression ratio is more important than speed.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "enableDictionaryCompression",
+          "type": "bool",
+          "description": "(Optional) Indicates whether to enable dictionary compression.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "maxPaddingBytes",
+          "type": "number",
+          "description": "(Optional) The maximum amount of padding to apply. This is useful if you intend to copy the data from Amazon S3 to HDFS before querying. The default is `0`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "pageSizeBytes",
+          "type": "number",
+          "description": "(Optional) The Parquet page size. Column chunks are divided into pages. A page is conceptually an indivisible unit (in terms of compression and encoding). The minimum value is 64 KiB and the default is 1 MiB.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "writerVersion",
+          "type": "string",
+          "description": "(Optional) Indicates the version of row format to output. The possible values are `V1` and `V2`. The default is `V1`.",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "schemaConfiguration",
+      "full_name": "ExtendedS3ConfigurationDataFormatConversionConfigurationSchemaConfiguration",
+      "arguments": [
+        {
+          "name": "catalogId",
+          "type": "string",
+          "description": "(Optional) The ID of the AWS Glue Data Catalog. If you don't supply this, the AWS account ID is used by default.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "databaseName",
+          "type": "string",
+          "description": "(Required) Specifies the name of the AWS Glue database that contains the schema for the output data.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "region",
+          "type": "string",
+          "description": "(Optional) If you don't specify an AWS Region, the default is the current region.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "roleArn",
+          "type": "string",
+          "description": "(Required) The role that Kinesis Data Firehose can use to access AWS Glue. This role must be in the same account you use for Kinesis Data Firehose. Cross-account roles aren't allowed.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "tableName",
+          "type": "string",
+          "description": "(Required) Specifies the AWS Glue table that contains the column information that constitutes your data schema.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "versionId",
+          "type": "string",
+          "description": "(Optional) Specifies the table version for the output data schema. Defaults to `LATEST`.",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "dynamicPartitioningConfiguration",
+      "full_name": "ExtendedS3ConfigurationDynamicPartitioningConfiguration",
+      "arguments": [
+        {
+          "name": "enabled",
+          "type": "bool",
+          "description": "(Optional) Enables or disables dynamic partitioning. Defaults to `false`. **NOTE:** You can enable dynamic partitioning only when you create a new delivery stream. Once you enable dynamic partitioning on a delivery stream, it cannot be disabled on this delivery stream. Therefore, Terraform will recreate the resource whenever dynamic partitioning is enabled or disabled.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "retryDuration",
+          "type": "number",
+          "description": "(Optional) Total amount of seconds Firehose spends on retries. Valid values between 0 and 7200. Default is 300.",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "processingConfiguration",
+      "full_name": "ExtendedS3ConfigurationProcessingConfiguration",
+      "arguments": [
+        {
+          "name": "enabled",
+          "type": "bool",
+          "description": "(Optional) Enables or disables data processing.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "processors",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "processors",
+      "full_name": "ExtendedS3ConfigurationProcessingConfigurationProcessors",
+      "arguments": [
+        {
+          "name": "type",
+          "type": "string",
+          "description": "(Required) The type of processor. Valid Values: `RecordDeAggregation`, `Lambda`, `MetadataExtraction`, `AppendDelimiterToRecord`, `Decompression`, `CloudWatchLogProcessing`. Validation is done against [AWS SDK constants](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/firehose/types#ProcessorType); so values not explicitly listed may also work.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "parameters",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "parameters",
+      "full_name": "ExtendedS3ConfigurationProcessingConfigurationProcessorsParameters",
+      "arguments": [
+        {
+          "name": "parameterName",
+          "type": "string",
+          "description": "(Required) Parameter name. Valid Values: `LambdaArn`, `NumberOfRetries`, `MetadataExtractionQuery`, `JsonParsingEngine`, `RoleArn`, `BufferSizeInMBs`, `BufferIntervalInSeconds`, `SubRecordType`, `Delimiter`, `CompressionFormat`, `DataMessageExtraction`. Validation is done against [AWS SDK constants](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/firehose/types#ProcessorParameterName); so values not explicitly listed may also work.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "parameterValue",
+          "type": "string",
+          "description": "(Required) Parameter value. Must be between 1 and 512 length (inclusive). When providing a Lambda ARN, you should specify the resource version as well.",
+          "required": true,
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "s3BackupConfiguration",
+      "full_name": "ExtendedS3ConfigurationS3BackupConfiguration",
+      "arguments": [
+        {
+          "name": "bucketArn",
+          "type": "string",
+          "description": "(Required) The ARN of the S3 bucket",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "bufferingInterval",
+          "type": "number",
+          "description": "(Optional) Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. The default value is 300.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "bufferingSize",
+          "type": "number",
+          "description": "(Optional) Buffer incoming data to the specified size, in MBs, before delivering it to the destination. The default value is 5.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "compressionFormat",
+          "type": "string",
+          "description": "(Optional) The compression format. If no value is specified, the default is `UNCOMPRESSED`. Other supported values are `GZIP`, `ZIP`, `Snappy`, \u0026 `HADOOP_SNAPPY`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "errorOutputPrefix",
+          "type": "string",
+          "description": "(Optional) Prefix added to failed records before writing them to S3. Not currently supported for `redshift` destination. This prefix appears immediately following the bucket name. For information about how to specify this prefix, see [Custom Prefixes for Amazon S3 Objects](https://docs.aws.amazon.com/firehose/latest/dev/s3-prefixes.html).",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "kmsKeyArn",
+          "type": "string",
+          "description": "(Optional) Specifies the KMS key ARN the stream will use to encrypt data. If not set, no encryption will be used.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "prefix",
+          "type": "string",
+          "description": "(Optional) The \"YYYY/MM/DD/HH\" time format prefix is automatically used for delivered S3 files. You can specify an extra prefix to be added in front of the time format prefix. Note that if the prefix ends with a slash, it appears as a folder in the S3 bucket",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "roleArn",
+          "type": "string",
+          "description": "(Required) The ARN of the AWS credentials.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "cloudwatchLoggingOptions",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "cloudwatchLoggingOptions",
+      "full_name": "ExtendedS3ConfigurationS3BackupConfigurationCloudwatchLoggingOptions",
+      "arguments": [
+        {
+          "name": "enabled",
+          "type": "bool",
+          "description": "(Optional) Enables or disables the logging. Defaults to `false`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "logGroupName",
+          "type": "string",
+          "description": "(Optional) The CloudWatch group name for logging. This value is required if `enabled` is true.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "logStreamName",
+          "type": "string",
+          "description": "(Optional) The CloudWatch log stream name for logging. This value is required if `enabled` is true.",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "httpEndpointConfiguration",
+      "full_name": "HttpEndpointConfiguration",
+      "arguments": [
+        {
+          "name": "accessKey",
+          "type": "string",
+          "description": "(Optional) The access key required for Kinesis Firehose to authenticate with the HTTP endpoint selected as the destination.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "bufferingInterval",
+          "type": "number",
+          "description": "(Optional) Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. The default value is 300 (5 minutes).",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "bufferingSize",
+          "type": "number",
+          "description": "(Optional) Buffer incoming data to the specified size, in MBs, before delivering it to the destination. The default value is 5.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "description": "(Optional) The HTTP endpoint name.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "retryDuration",
+          "type": "number",
+          "description": "(Optional) Total amount of seconds Firehose spends on retries. This duration starts after the initial attempt fails, It does not include the time periods during which Firehose waits for acknowledgment from the specified destination after each attempt. Valid values between `0` and `7200`. Default is `300`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "roleArn",
+          "type": "string",
+          "description": "(Required) Kinesis Data Firehose uses this IAM role for all the permissions that the delivery stream needs. The pattern needs to be `arn:.*`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "s3BackupMode",
+          "type": "string",
+          "description": "(Optional) Defines how documents should be delivered to Amazon S3.  Valid values are `FailedDataOnly` and `AllData`.  Default value is `FailedDataOnly`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "url",
+          "type": "string",
+          "description": "(Required) The HTTP endpoint URL to which Kinesis Firehose sends your data.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "cloudwatchLoggingOptions",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "processingConfiguration",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "requestConfiguration",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "s3Configuration",
+          "type": "block",
+          "description": "",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "secretsManagerConfiguration",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "cloudwatchLoggingOptions",
+      "full_name": "HttpEndpointConfigurationCloudwatchLoggingOptions",
+      "arguments": [
+        {
+          "name": "enabled",
+          "type": "bool",
+          "description": "(Optional) Enables or disables the logging. Defaults to `false`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "logGroupName",
+          "type": "string",
+          "description": "(Optional) The CloudWatch group name for logging. This value is required if `enabled` is true.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "logStreamName",
+          "type": "string",
+          "description": "(Optional) The CloudWatch log stream name for logging. This value is required if `enabled` is true.",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "processingConfiguration",
+      "full_name": "HttpEndpointConfigurationProcessingConfiguration",
+      "arguments": [
+        {
+          "name": "enabled",
+          "type": "bool",
+          "description": "(Optional) Enables or disables data processing.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "processors",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "processors",
+      "full_name": "HttpEndpointConfigurationProcessingConfigurationProcessors",
+      "arguments": [
+        {
+          "name": "type",
+          "type": "string",
+          "description": "(Required) The type of processor. Valid Values: `RecordDeAggregation`, `Lambda`, `MetadataExtraction`, `AppendDelimiterToRecord`, `Decompression`, `CloudWatchLogProcessing`. Validation is done against [AWS SDK constants](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/firehose/types#ProcessorType); so values not explicitly listed may also work.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "parameters",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "parameters",
+      "full_name": "HttpEndpointConfigurationProcessingConfigurationProcessorsParameters",
+      "arguments": [
+        {
+          "name": "parameterName",
+          "type": "string",
+          "description": "(Required) Parameter name. Valid Values: `LambdaArn`, `NumberOfRetries`, `MetadataExtractionQuery`, `JsonParsingEngine`, `RoleArn`, `BufferSizeInMBs`, `BufferIntervalInSeconds`, `SubRecordType`, `Delimiter`, `CompressionFormat`, `DataMessageExtraction`. Validation is done against [AWS SDK constants](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/firehose/types#ProcessorParameterName); so values not explicitly listed may also work.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "parameterValue",
+          "type": "string",
+          "description": "(Required) Parameter value. Must be between 1 and 512 length (inclusive). When providing a Lambda ARN, you should specify the resource version as well.",
+          "required": true,
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "requestConfiguration",
+      "full_name": "HttpEndpointConfigurationRequestConfiguration",
+      "arguments": [
+        {
+          "name": "contentEncoding",
+          "type": "string",
+          "description": "(Optional) Kinesis Data Firehose uses the content encoding to compress the body of a request before sending the request to the destination. Valid values are `NONE` and `GZIP`.  Default value is `NONE`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "commonAttributes",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "commonAttributes",
+      "full_name": "HttpEndpointConfigurationRequestConfigurationCommonAttributes",
+      "arguments": [
+        {
+          "name": "name",
+          "type": "string",
+          "description": "(Required) The name of the HTTP endpoint common attribute.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "value",
+          "type": "string",
+          "description": "(Required) The value of the HTTP endpoint common attribute.",
+          "required": true,
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "s3Configuration",
+      "full_name": "HttpEndpointConfigurationS3Configuration",
+      "arguments": [
+        {
+          "name": "bucketArn",
+          "type": "string",
+          "description": "(Required) The ARN of the S3 bucket",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "bufferingInterval",
+          "type": "number",
+          "description": "(Optional) Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. The default value is 300 (5 minutes).",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "bufferingSize",
+          "type": "number",
+          "description": "(Optional) Buffer incoming data to the specified size, in MBs, before delivering it to the destination. The default value is 5. We recommend setting SizeInMBs to a value greater than the amount of data you typically ingest into the delivery stream in 10 seconds. For example, if you typically ingest data at 1 MB/sec set SizeInMBs to be 10 MB or higher.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "compressionFormat",
+          "type": "string",
+          "description": "(Optional) The compression format. If no value is specified, the default is `UNCOMPRESSED`. Other supported values are `GZIP`, `ZIP`, `Snappy`, \u0026 `HADOOP_SNAPPY`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "errorOutputPrefix",
+          "type": "string",
+          "description": "(Optional) Prefix added to failed records before writing them to S3. Not currently supported for `redshift` destination. This prefix appears immediately following the bucket name. For information about how to specify this prefix, see [Custom Prefixes for Amazon S3 Objects](https://docs.aws.amazon.com/firehose/latest/dev/s3-prefixes.html).",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "kmsKeyArn",
+          "type": "string",
+          "description": "(Optional) Specifies the KMS key ARN the stream will use to encrypt data. If not set, no encryption will be used.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "prefix",
+          "type": "string",
+          "description": "(Optional) The \"YYYY/MM/DD/HH\" time format prefix is automatically used for delivered S3 files. You can specify an extra prefix to be added in front of the time format prefix. Note that if the prefix ends with a slash, it appears as a folder in the S3 bucket",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "roleArn",
+          "type": "string",
+          "description": "(Required) The ARN of the AWS credentials.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "cloudwatchLoggingOptions",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "cloudwatchLoggingOptions",
+      "full_name": "HttpEndpointConfigurationS3ConfigurationCloudwatchLoggingOptions",
+      "arguments": [
+        {
+          "name": "enabled",
+          "type": "bool",
+          "description": "(Optional) Enables or disables the logging. Defaults to `false`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "logGroupName",
+          "type": "string",
+          "description": "(Optional) The CloudWatch group name for logging. This value is required if `enabled` is true.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "logStreamName",
+          "type": "string",
+          "description": "(Optional) The CloudWatch log stream name for logging. This value is required if `enabled` is true.",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "secretsManagerConfiguration",
+      "full_name": "HttpEndpointConfigurationSecretsManagerConfiguration",
+      "arguments": [
+        {
+          "name": "enabled",
+          "type": "bool",
+          "description": "(Optional) Enables or disables the Secrets Manager configuration.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "roleArn",
+          "type": "string",
+          "description": "(Optional) The ARN of the Secrets Manager secret. This value is required if `enabled` is true.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "secretArn",
+          "type": "string",
+          "description": "(Optional) The ARN of the Secrets Manager secret. This value is required if `enabled` is true.",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "icebergConfiguration",
+      "full_name": "IcebergConfiguration",
+      "arguments": [
+        {
+          "name": "bufferingInterval",
+          "type": "number",
+          "description": "(Optional) Buffer incoming data for the specified period of time, in seconds between 0 and 900, before delivering it to the destination. The default value is 300.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "bufferingSize",
+          "type": "number",
+          "description": "(Optional) Buffer incoming data to the specified size, in MBs between 1 and 128, before delivering it to the destination. The default value is 5.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "catalogArn",
+          "type": "string",
+          "description": "(Required) Glue catalog ARN identifier of the destination Apache Iceberg Tables. You must specify the ARN in the format `arn:aws:glue:region:account-id:catalog`",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "retryDuration",
+          "type": "number",
+          "description": "(Optional) The period of time, in seconds between 0 to 7200, during which Firehose retries to deliver data to the specified destination.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "roleArn",
+          "type": "string",
+          "description": "(Required) The ARN of the IAM role to be assumed by Firehose for calling Apache Iceberg Tables.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "s3BackupMode",
+          "type": "string",
+          "description": "(Optional) Defines how documents should be delivered to Amazon S3.  Valid values are `FailedDataOnly` and `AllData`.  Default value is `FailedDataOnly`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "cloudwatchLoggingOptions",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "destinationTableConfiguration",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "processingConfiguration",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "s3Configuration",
+          "type": "block",
+          "description": "",
+          "required": true,
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "cloudwatchLoggingOptions",
+      "full_name": "IcebergConfigurationCloudwatchLoggingOptions",
+      "arguments": [
+        {
+          "name": "enabled",
+          "type": "bool",
+          "description": "(Optional) Enables or disables the logging. Defaults to `false`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "logGroupName",
+          "type": "string",
+          "description": "(Optional) The CloudWatch group name for logging. This value is required if `enabled` is true.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "logStreamName",
+          "type": "string",
+          "description": "(Optional) The CloudWatch log stream name for logging. This value is required if `enabled` is true.",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "destinationTableConfiguration",
+      "full_name": "IcebergConfigurationDestinationTableConfiguration",
+      "arguments": [
+        {
+          "name": "databaseName",
+          "type": "string",
+          "description": "(Required) The name of the Apache Iceberg database.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "s3ErrorOutputPrefix",
+          "type": "string",
+          "description": "(Optional) The table specific S3 error output prefix. All the errors that occurred while delivering to this table will be prefixed with this value in S3 destination.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "tableName",
+          "type": "string",
+          "description": "(Required) The name of the Apache Iceberg Table.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "uniqueKeys",
+          "type": "list",
+          "description": "(Optional) A list of unique keys for a given Apache Iceberg table. Firehose will use these for running Create, Update, or Delete operations on the given Iceberg table.",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "processingConfiguration",
+      "full_name": "IcebergConfigurationProcessingConfiguration",
+      "arguments": [
+        {
+          "name": "enabled",
+          "type": "bool",
+          "description": "(Optional) Enables or disables data processing.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "processors",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "processors",
+      "full_name": "IcebergConfigurationProcessingConfigurationProcessors",
+      "arguments": [
+        {
+          "name": "type",
+          "type": "string",
+          "description": "(Required) The type of processor. Valid Values: `RecordDeAggregation`, `Lambda`, `MetadataExtraction`, `AppendDelimiterToRecord`, `Decompression`, `CloudWatchLogProcessing`. Validation is done against [AWS SDK constants](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/firehose/types#ProcessorType); so values not explicitly listed may also work.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "parameters",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "parameters",
+      "full_name": "IcebergConfigurationProcessingConfigurationProcessorsParameters",
+      "arguments": [
+        {
+          "name": "parameterName",
+          "type": "string",
+          "description": "(Required) Parameter name. Valid Values: `LambdaArn`, `NumberOfRetries`, `MetadataExtractionQuery`, `JsonParsingEngine`, `RoleArn`, `BufferSizeInMBs`, `BufferIntervalInSeconds`, `SubRecordType`, `Delimiter`, `CompressionFormat`, `DataMessageExtraction`. Validation is done against [AWS SDK constants](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/firehose/types#ProcessorParameterName); so values not explicitly listed may also work.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "parameterValue",
+          "type": "string",
+          "description": "(Required) Parameter value. Must be between 1 and 512 length (inclusive). When providing a Lambda ARN, you should specify the resource version as well.",
+          "required": true,
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "s3Configuration",
+      "full_name": "IcebergConfigurationS3Configuration",
+      "arguments": [
+        {
+          "name": "bucketArn",
+          "type": "string",
+          "description": "(Required) The ARN of the S3 bucket",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "bufferingInterval",
+          "type": "number",
+          "description": "(Optional) Buffer incoming data for the specified period of time, in seconds between 0 and 900, before delivering it to the destination. The default value is 300. (5 minutes).",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "bufferingSize",
+          "type": "number",
+          "description": "(Optional) Buffer incoming data to the specified size, in MBs between 1 and 128, before delivering it to the destination. The default value is 5.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "compressionFormat",
+          "type": "string",
+          "description": "(Optional) The compression format. If no value is specified, the default is `UNCOMPRESSED`. Other supported values are `GZIP`, `ZIP`, `Snappy`, \u0026 `HADOOP_SNAPPY`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "errorOutputPrefix",
+          "type": "string",
+          "description": "(Optional) Prefix added to failed records before writing them to S3. Not currently supported for `redshift` destination. This prefix appears immediately following the bucket name. For information about how to specify this prefix, see [Custom Prefixes for Amazon S3 Objects](https://docs.aws.amazon.com/firehose/latest/dev/s3-prefixes.html).",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "kmsKeyArn",
+          "type": "string",
+          "description": "(Optional) Specifies the KMS key ARN the stream will use to encrypt data. If not set, no encryption will be used.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "prefix",
+          "type": "string",
+          "description": "(Optional) The \"YYYY/MM/DD/HH\" time format prefix is automatically used for delivered S3 files. You can specify an extra prefix to be added in front of the time format prefix. Note that if the prefix ends with a slash, it appears as a folder in the S3 bucket",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "roleArn",
+          "type": "string",
+          "description": "(Required) The ARN of the IAM role to be assumed by Firehose for calling Apache Iceberg Tables.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "cloudwatchLoggingOptions",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "cloudwatchLoggingOptions",
+      "full_name": "IcebergConfigurationS3ConfigurationCloudwatchLoggingOptions",
+      "arguments": [
+        {
+          "name": "enabled",
+          "type": "bool",
+          "description": "(Optional) Enables or disables the logging. Defaults to `false`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "logGroupName",
+          "type": "string",
+          "description": "(Optional) The CloudWatch group name for logging. This value is required if `enabled` is true.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "logStreamName",
+          "type": "string",
+          "description": "(Optional) The CloudWatch log stream name for logging. This value is required if `enabled` is true.",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "kinesisSourceConfiguration",
+      "full_name": "KinesisSourceConfiguration",
+      "arguments": [
+        {
+          "name": "kinesisStreamArn",
+          "type": "string",
+          "description": "(Required) The kinesis stream used as the source of the firehose delivery stream.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "roleArn",
+          "type": "string",
+          "description": "(Required) The ARN of the role that provides access to the source Kinesis stream.",
+          "required": true,
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "mskSourceConfiguration",
+      "full_name": "MskSourceConfiguration",
+      "arguments": [
+        {
+          "name": "mskClusterArn",
+          "type": "string",
+          "description": "(Required) The ARN of the Amazon MSK cluster.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "readFromTimestamp",
+          "type": "string",
+          "description": "(Optional) The start date and time in UTC for the offset position within your MSK topic from where Firehose begins to read. By default, this is set to timestamp when Firehose becomes Active. If you want to create a Firehose stream with Earliest start position set the `readFromTimestamp` parameter to Epoch (1970-01-01T00:00:00Z).",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "topicName",
+          "type": "string",
+          "description": "(Required) The topic name within the Amazon MSK cluster.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "authenticationConfiguration",
+          "type": "block",
+          "description": "",
+          "required": true,
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "authenticationConfiguration",
+      "full_name": "MskSourceConfigurationAuthenticationConfiguration",
+      "arguments": [
+        {
+          "name": "connectivity",
+          "type": "string",
+          "description": "(Required) The type of connectivity used to access the Amazon MSK cluster. Valid values: `PUBLIC`, `PRIVATE`.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "roleArn",
+          "type": "string",
+          "description": "(Required) The ARN of the role used to access the Amazon MSK cluster.",
+          "required": true,
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "opensearchConfiguration",
+      "full_name": "OpensearchConfiguration",
+      "arguments": [
+        {
+          "name": "bufferingInterval",
+          "type": "number",
+          "description": "(Optional) Buffer incoming data for the specified period of time, in seconds between 0 to 900, before delivering it to the destination.  The default value is 300s.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "bufferingSize",
+          "type": "number",
+          "description": "(Optional) Buffer incoming data to the specified size, in MBs between 1 to 100, before delivering it to the destination.  The default value is 5MB.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "clusterEndpoint",
+          "type": "string",
+          "description": "(Optional) The endpoint to use when communicating with the cluster. Conflicts with `domainArn`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "domainArn",
+          "type": "string",
+          "description": "(Optional) The ARN of the Amazon ES domain.  The pattern needs to be `arn:.*`.  Conflicts with `clusterEndpoint`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "indexName",
+          "type": "string",
+          "description": "(Required) The OpenSearch index name.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "indexRotationPeriod",
+          "type": "string",
+          "description": "(Optional) The OpenSearch index rotation period.  Index rotation appends a timestamp to the IndexName to facilitate expiration of old data.  Valid values are `NoRotation`, `OneHour`, `OneDay`, `OneWeek`, and `OneMonth`.  The default value is `OneDay`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "retryDuration",
+          "type": "number",
+          "description": "(Optional) After an initial failure to deliver to Amazon OpenSearch, the total amount of time, in seconds between 0 to 7200, during which Firehose re-attempts delivery (including the first attempt).  After this time has elapsed, the failed documents are written to Amazon S3.  The default value is 300s.  There will be no retry if the value is 0.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "roleArn",
+          "type": "string",
+          "description": "(Required) The ARN of the IAM role to be assumed by Firehose for calling the Amazon ES Configuration API and for indexing documents.  The IAM role must have permission for `DescribeDomain`, `DescribeDomains`, and `DescribeDomainConfig`.  The pattern needs to be `arn:.*`.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "s3BackupMode",
+          "type": "string",
+          "description": "(Optional) Defines how documents should be delivered to Amazon S3.  Valid values are `FailedDocumentsOnly` and `AllDocuments`.  Default value is `FailedDocumentsOnly`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "typeName",
+          "type": "string",
+          "description": "(Optional) The Elasticsearch type name with maximum length of 100 characters. Types are deprecated in OpenSearch_1.1. TypeName must be empty.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "cloudwatchLoggingOptions",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "documentIdOptions",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "processingConfiguration",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "s3Configuration",
+          "type": "block",
+          "description": "",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "vpcConfig",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "cloudwatchLoggingOptions",
+      "full_name": "OpensearchConfigurationCloudwatchLoggingOptions",
+      "arguments": [
+        {
+          "name": "enabled",
+          "type": "bool",
+          "description": "(Optional) Enables or disables the logging. Defaults to `false`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "logGroupName",
+          "type": "string",
+          "description": "(Optional) The CloudWatch group name for logging. This value is required if `enabled` is true.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "logStreamName",
+          "type": "string",
+          "description": "(Optional) The CloudWatch log stream name for logging. This value is required if `enabled` is true.",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "documentIdOptions",
+      "full_name": "OpensearchConfigurationDocumentIdOptions",
+      "arguments": [
+        {
+          "name": "defaultDocumentIdFormat",
+          "type": "string",
+          "description": "(Required) The method for setting up document ID. Valid values: `FIREHOSE_DEFAULT`, `NO_DOCUMENT_ID`.",
+          "required": true,
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "processingConfiguration",
+      "full_name": "OpensearchConfigurationProcessingConfiguration",
+      "arguments": [
+        {
+          "name": "enabled",
+          "type": "bool",
+          "description": "(Optional) Enables or disables data processing.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "processors",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "processors",
+      "full_name": "OpensearchConfigurationProcessingConfigurationProcessors",
+      "arguments": [
+        {
+          "name": "type",
+          "type": "string",
+          "description": "(Required) The type of processor. Valid Values: `RecordDeAggregation`, `Lambda`, `MetadataExtraction`, `AppendDelimiterToRecord`, `Decompression`, `CloudWatchLogProcessing`. Validation is done against [AWS SDK constants](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/firehose/types#ProcessorType); so values not explicitly listed may also work.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "parameters",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "parameters",
+      "full_name": "OpensearchConfigurationProcessingConfigurationProcessorsParameters",
+      "arguments": [
+        {
+          "name": "parameterName",
+          "type": "string",
+          "description": "(Required) Parameter name. Valid Values: `LambdaArn`, `NumberOfRetries`, `MetadataExtractionQuery`, `JsonParsingEngine`, `RoleArn`, `BufferSizeInMBs`, `BufferIntervalInSeconds`, `SubRecordType`, `Delimiter`, `CompressionFormat`, `DataMessageExtraction`. Validation is done against [AWS SDK constants](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/firehose/types#ProcessorParameterName); so values not explicitly listed may also work.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "parameterValue",
+          "type": "string",
+          "description": "(Required) Parameter value. Must be between 1 and 512 length (inclusive). When providing a Lambda ARN, you should specify the resource version as well.",
+          "required": true,
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "s3Configuration",
+      "full_name": "OpensearchConfigurationS3Configuration",
+      "arguments": [
+        {
+          "name": "bucketArn",
+          "type": "string",
+          "description": "(Required) The ARN of the S3 bucket",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "bufferingInterval",
+          "type": "number",
+          "description": "(Optional) Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. The default value is 300 (5 minutes).",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "bufferingSize",
+          "type": "number",
+          "description": "(Optional) Buffer incoming data to the specified size, in MBs, before delivering it to the destination. The default value is 5.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "compressionFormat",
+          "type": "string",
+          "description": "(Optional) The compression format. If no value is specified, the default is `UNCOMPRESSED`. Other supported values are `GZIP`, `ZIP`, `Snappy`, \u0026 `HADOOP_SNAPPY`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "errorOutputPrefix",
+          "type": "string",
+          "description": "(Optional) Prefix added to failed records before writing them to S3. Not currently supported for `redshift` destination. This prefix appears immediately following the bucket name. For information about how to specify this prefix, see [Custom Prefixes for Amazon S3 Objects](https://docs.aws.amazon.com/firehose/latest/dev/s3-prefixes.html).",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "kmsKeyArn",
+          "type": "string",
+          "description": "(Optional) Specifies the KMS key ARN the stream will use to encrypt data. If not set, no encryption will be used.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "prefix",
+          "type": "string",
+          "description": "(Optional) The \"YYYY/MM/DD/HH\" time format prefix is automatically used for delivered S3 files. You can specify an extra prefix to be added in front of the time format prefix. Note that if the prefix ends with a slash, it appears as a folder in the S3 bucket",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "roleArn",
+          "type": "string",
+          "description": "(Required) The ARN of the AWS credentials.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "cloudwatchLoggingOptions",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "cloudwatchLoggingOptions",
+      "full_name": "OpensearchConfigurationS3ConfigurationCloudwatchLoggingOptions",
+      "arguments": [
+        {
+          "name": "enabled",
+          "type": "bool",
+          "description": "(Optional) Enables or disables the logging. Defaults to `false`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "logGroupName",
+          "type": "string",
+          "description": "(Optional) The CloudWatch group name for logging. This value is required if `enabled` is true.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "logStreamName",
+          "type": "string",
+          "description": "(Optional) The CloudWatch log stream name for logging. This value is required if `enabled` is true.",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "vpcConfig",
+      "full_name": "OpensearchConfigurationVpcConfig",
+      "arguments": [
+        {
+          "name": "roleArn",
+          "type": "string",
+          "description": "(Required) The ARN of the IAM role to be assumed by Firehose for calling the Amazon EC2 configuration API and for creating network interfaces. Make sure role has necessary [IAM permissions](https://docs.aws.amazon.com/firehose/latest/dev/controlling-access.html#using-iam-es-vpc)",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "securityGroupIds",
+          "type": "set",
+          "description": "(Required) A list of security group IDs to associate with Kinesis Firehose.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "subnetIds",
+          "type": "set",
+          "description": "(Required) A list of subnet IDs to associate with Kinesis Firehose.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "vpcId",
+          "type": "string",
+          "description": "",
+          "required": false,
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "opensearchserverlessConfiguration",
+      "full_name": "OpensearchserverlessConfiguration",
+      "arguments": [
+        {
+          "name": "bufferingInterval",
+          "type": "number",
+          "description": "(Optional) Buffer incoming data for the specified period of time, in seconds between 0 to 900, before delivering it to the destination.  The default value is 300s.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "bufferingSize",
+          "type": "number",
+          "description": "(Optional) Buffer incoming data to the specified size, in MBs between 1 to 100, before delivering it to the destination.  The default value is 5MB.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "collectionEndpoint",
+          "type": "string",
+          "description": "(Required) The endpoint to use when communicating with the collection in the Serverless offering for Amazon OpenSearch Service.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "indexName",
+          "type": "string",
+          "description": "(Required) The Serverless offering for Amazon OpenSearch Service index name.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "retryDuration",
+          "type": "number",
+          "description": "(Optional) After an initial failure to deliver to the Serverless offering for Amazon OpenSearch Service, the total amount of time, in seconds between 0 to 7200, during which Kinesis Data Firehose retries delivery (including the first attempt).  After this time has elapsed, the failed documents are written to Amazon S3.  The default value is 300s.  There will be no retry if the value is 0.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "roleArn",
+          "type": "string",
+          "description": "(Required) The Amazon Resource Name (ARN) of the IAM role to be assumed by Kinesis Data Firehose for calling the Serverless offering for Amazon OpenSearch Service Configuration API and for indexing documents.  The pattern needs to be `arn:.*`.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "s3BackupMode",
+          "type": "string",
+          "description": "(Optional) Defines how documents should be delivered to Amazon S3.  Valid values are `FailedDocumentsOnly` and `AllDocuments`.  Default value is `FailedDocumentsOnly`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "cloudwatchLoggingOptions",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "processingConfiguration",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "s3Configuration",
+          "type": "block",
+          "description": "",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "vpcConfig",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "cloudwatchLoggingOptions",
+      "full_name": "OpensearchserverlessConfigurationCloudwatchLoggingOptions",
+      "arguments": [
+        {
+          "name": "enabled",
+          "type": "bool",
+          "description": "(Optional) Enables or disables the logging. Defaults to `false`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "logGroupName",
+          "type": "string",
+          "description": "(Optional) The CloudWatch group name for logging. This value is required if `enabled` is true.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "logStreamName",
+          "type": "string",
+          "description": "(Optional) The CloudWatch log stream name for logging. This value is required if `enabled` is true.",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "processingConfiguration",
+      "full_name": "OpensearchserverlessConfigurationProcessingConfiguration",
+      "arguments": [
+        {
+          "name": "enabled",
+          "type": "bool",
+          "description": "(Optional) Enables or disables data processing.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "processors",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "processors",
+      "full_name": "OpensearchserverlessConfigurationProcessingConfigurationProcessors",
+      "arguments": [
+        {
+          "name": "type",
+          "type": "string",
+          "description": "(Required) The type of processor. Valid Values: `RecordDeAggregation`, `Lambda`, `MetadataExtraction`, `AppendDelimiterToRecord`, `Decompression`, `CloudWatchLogProcessing`. Validation is done against [AWS SDK constants](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/firehose/types#ProcessorType); so values not explicitly listed may also work.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "parameters",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "parameters",
+      "full_name": "OpensearchserverlessConfigurationProcessingConfigurationProcessorsParameters",
+      "arguments": [
+        {
+          "name": "parameterName",
+          "type": "string",
+          "description": "(Required) Parameter name. Valid Values: `LambdaArn`, `NumberOfRetries`, `MetadataExtractionQuery`, `JsonParsingEngine`, `RoleArn`, `BufferSizeInMBs`, `BufferIntervalInSeconds`, `SubRecordType`, `Delimiter`, `CompressionFormat`, `DataMessageExtraction`. Validation is done against [AWS SDK constants](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/firehose/types#ProcessorParameterName); so values not explicitly listed may also work.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "parameterValue",
+          "type": "string",
+          "description": "(Required) Parameter value. Must be between 1 and 512 length (inclusive). When providing a Lambda ARN, you should specify the resource version as well.",
+          "required": true,
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "s3Configuration",
+      "full_name": "OpensearchserverlessConfigurationS3Configuration",
+      "arguments": [
+        {
+          "name": "bucketArn",
+          "type": "string",
+          "description": "(Required) The ARN of the S3 bucket",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "bufferingInterval",
+          "type": "number",
+          "description": "(Optional) Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. The default value is 300 (5 minutes).",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "bufferingSize",
+          "type": "number",
+          "description": "(Optional) Buffer incoming data to the specified size, in MBs, before delivering it to the destination. The default value is 5. We recommend setting SizeInMBs to a value greater than the amount of data you typically ingest into the delivery stream in 10 seconds. For example, if you typically ingest data at 1 MB/sec set SizeInMBs to be 10 MB or higher.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "compressionFormat",
+          "type": "string",
+          "description": "(Optional) The compression format. If no value is specified, the default is `UNCOMPRESSED`. Other supported values are `GZIP`, `ZIP`, `Snappy`, \u0026 `HADOOP_SNAPPY`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "errorOutputPrefix",
+          "type": "string",
+          "description": "(Optional) Prefix added to failed records before writing them to S3. Not currently supported for `redshift` destination. This prefix appears immediately following the bucket name. For information about how to specify this prefix, see [Custom Prefixes for Amazon S3 Objects](https://docs.aws.amazon.com/firehose/latest/dev/s3-prefixes.html).",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "kmsKeyArn",
+          "type": "string",
+          "description": "(Optional) Specifies the KMS key ARN the stream will use to encrypt data. If not set, no encryption will be used.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "prefix",
+          "type": "string",
+          "description": "(Optional) The \"YYYY/MM/DD/HH\" time format prefix is automatically used for delivered S3 files. You can specify an extra prefix to be added in front of the time format prefix. Note that if the prefix ends with a slash, it appears as a folder in the S3 bucket",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "roleArn",
+          "type": "string",
+          "description": "(Required) The ARN of the AWS credentials.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "cloudwatchLoggingOptions",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "cloudwatchLoggingOptions",
+      "full_name": "OpensearchserverlessConfigurationS3ConfigurationCloudwatchLoggingOptions",
+      "arguments": [
+        {
+          "name": "enabled",
+          "type": "bool",
+          "description": "(Optional) Enables or disables the logging. Defaults to `false`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "logGroupName",
+          "type": "string",
+          "description": "(Optional) The CloudWatch group name for logging. This value is required if `enabled` is true.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "logStreamName",
+          "type": "string",
+          "description": "(Optional) The CloudWatch log stream name for logging. This value is required if `enabled` is true.",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "vpcConfig",
+      "full_name": "OpensearchserverlessConfigurationVpcConfig",
+      "arguments": [
+        {
+          "name": "roleArn",
+          "type": "string",
+          "description": "(Required) The ARN of the IAM role to be assumed by Firehose for calling the Amazon EC2 configuration API and for creating network interfaces. Make sure role has necessary [IAM permissions](https://docs.aws.amazon.com/firehose/latest/dev/controlling-access.html#using-iam-es-vpc)",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "securityGroupIds",
+          "type": "set",
+          "description": "(Required) A list of security group IDs to associate with Kinesis Firehose.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "subnetIds",
+          "type": "set",
+          "description": "(Required) A list of subnet IDs to associate with Kinesis Firehose.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "vpcId",
+          "type": "string",
+          "description": "",
+          "required": false,
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "redshiftConfiguration",
+      "full_name": "RedshiftConfiguration",
+      "arguments": [
+        {
+          "name": "clusterJdbcurl",
+          "type": "string",
+          "description": "(Required) The jdbcurl of the redshift cluster.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "copyOptions",
+          "type": "string",
+          "description": "(Optional) Copy options for copying the data from the s3 intermediate bucket into redshift, for example to change the default delimiter. For valid values, see the [AWS documentation](http://docs.aws.amazon.com/firehose/latest/APIReference/API_CopyCommand.html)",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "dataTableColumns",
+          "type": "string",
+          "description": "(Optional) The data table columns that will be targeted by the copy command.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "dataTableName",
+          "type": "string",
+          "description": "(Required) The name of the table in the redshift cluster that the s3 bucket will copy to.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "password",
+          "type": "string",
+          "description": "(Optional) The password for the username above. This value is required if `secretsManagerConfiguration` is not provided.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "retryDuration",
+          "type": "number",
+          "description": "(Optional) The length of time during which Firehose retries delivery after a failure, starting from the initial request and including the first attempt. The default value is 3600 seconds (60 minutes). Firehose does not retry if the value of DurationInSeconds is 0 (zero) or if the first delivery attempt takes longer than the current value.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "roleArn",
+          "type": "string",
+          "description": "(Required) The arn of the role the stream assumes.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "s3BackupMode",
+          "type": "string",
+          "description": "(Optional) The Amazon S3 backup mode.  Valid values are `Disabled` and `Enabled`.  Default value is `Disabled`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "username",
+          "type": "string",
+          "description": "(Optional) The username that the firehose delivery stream will assume. It is strongly recommended that the username and password provided is used exclusively for Amazon Kinesis Firehose purposes, and that the permissions for the account are restricted for Amazon Redshift INSERT permissions. This value is required if `secretsManagerConfiguration` is not provided.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "s3Configuration",
+          "type": "block",
+          "description": "",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "secretsManagerConfiguration",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "cloudwatchLoggingOptions",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "processingConfiguration",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "s3BackupConfiguration",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "cloudwatchLoggingOptions",
+      "full_name": "RedshiftConfigurationCloudwatchLoggingOptions",
+      "arguments": [
+        {
+          "name": "enabled",
+          "type": "bool",
+          "description": "(Optional) Enables or disables the logging. Defaults to `false`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "logGroupName",
+          "type": "string",
+          "description": "(Optional) The CloudWatch group name for logging. This value is required if `enabled` is true.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "logStreamName",
+          "type": "string",
+          "description": "(Optional) The CloudWatch log stream name for logging. This value is required if `enabled` is true.",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "processingConfiguration",
+      "full_name": "RedshiftConfigurationProcessingConfiguration",
+      "arguments": [
+        {
+          "name": "enabled",
+          "type": "bool",
+          "description": "(Optional) Enables or disables data processing.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "processors",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "processors",
+      "full_name": "RedshiftConfigurationProcessingConfigurationProcessors",
+      "arguments": [
+        {
+          "name": "type",
+          "type": "string",
+          "description": "(Required) The type of processor. Valid Values: `RecordDeAggregation`, `Lambda`, `MetadataExtraction`, `AppendDelimiterToRecord`, `Decompression`, `CloudWatchLogProcessing`. Validation is done against [AWS SDK constants](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/firehose/types#ProcessorType); so values not explicitly listed may also work.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "parameters",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "parameters",
+      "full_name": "RedshiftConfigurationProcessingConfigurationProcessorsParameters",
+      "arguments": [
+        {
+          "name": "parameterName",
+          "type": "string",
+          "description": "(Required) Parameter name. Valid Values: `LambdaArn`, `NumberOfRetries`, `MetadataExtractionQuery`, `JsonParsingEngine`, `RoleArn`, `BufferSizeInMBs`, `BufferIntervalInSeconds`, `SubRecordType`, `Delimiter`, `CompressionFormat`, `DataMessageExtraction`. Validation is done against [AWS SDK constants](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/firehose/types#ProcessorParameterName); so values not explicitly listed may also work.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "parameterValue",
+          "type": "string",
+          "description": "(Required) Parameter value. Must be between 1 and 512 length (inclusive). When providing a Lambda ARN, you should specify the resource version as well.",
+          "required": true,
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "s3BackupConfiguration",
+      "full_name": "RedshiftConfigurationS3BackupConfiguration",
+      "arguments": [
+        {
+          "name": "bucketArn",
+          "type": "string",
+          "description": "(Required) The ARN of the S3 bucket",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "bufferingInterval",
+          "type": "number",
+          "description": "(Optional) Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. The default value is 300 (5 minutes).",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "bufferingSize",
+          "type": "number",
+          "description": "(Optional) Buffer incoming data to the specified size, in MBs, before delivering it to the destination. The default value is 5.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "compressionFormat",
+          "type": "string",
+          "description": "(Optional) The compression format. If no value is specified, the default is `UNCOMPRESSED`. Other supported values are `GZIP`, `ZIP`, `Snappy`, \u0026 `HADOOP_SNAPPY`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "errorOutputPrefix",
+          "type": "string",
+          "description": "(Optional) Prefix added to failed records before writing them to S3. Not currently supported for `redshift` destination. This prefix appears immediately following the bucket name. For information about how to specify this prefix, see [Custom Prefixes for Amazon S3 Objects](https://docs.aws.amazon.com/firehose/latest/dev/s3-prefixes.html).",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "kmsKeyArn",
+          "type": "string",
+          "description": "(Optional) Specifies the KMS key ARN the stream will use to encrypt data. If not set, no encryption will be used.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "prefix",
+          "type": "string",
+          "description": "(Optional) The \"YYYY/MM/DD/HH\" time format prefix is automatically used for delivered S3 files. You can specify an extra prefix to be added in front of the time format prefix. Note that if the prefix ends with a slash, it appears as a folder in the S3 bucket",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "roleArn",
+          "type": "string",
+          "description": "(Required) Kinesis Data Firehose uses this IAM role for all the permissions that the delivery stream needs. The pattern needs to be `arn:.*`.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "cloudwatchLoggingOptions",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "cloudwatchLoggingOptions",
+      "full_name": "RedshiftConfigurationS3BackupConfigurationCloudwatchLoggingOptions",
+      "arguments": [
+        {
+          "name": "enabled",
+          "type": "bool",
+          "description": "(Optional) Enables or disables the logging. Defaults to `false`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "logGroupName",
+          "type": "string",
+          "description": "(Optional) The CloudWatch group name for logging. This value is required if `enabled` is true.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "logStreamName",
+          "type": "string",
+          "description": "(Optional) The CloudWatch log stream name for logging. This value is required if `enabled` is true.",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "s3Configuration",
+      "full_name": "RedshiftConfigurationS3Configuration",
+      "arguments": [
+        {
+          "name": "bucketArn",
+          "type": "string",
+          "description": "(Required) The ARN of the S3 bucket",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "bufferingInterval",
+          "type": "number",
+          "description": "(Optional) Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. The default value is 300 (5 minutes).",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "bufferingSize",
+          "type": "number",
+          "description": "(Optional) Buffer incoming data to the specified size, in MBs, before delivering it to the destination. The default value is 5.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "compressionFormat",
+          "type": "string",
+          "description": "(Optional) The compression format. If no value is specified, the default is `UNCOMPRESSED`. Other supported values are `GZIP`, `ZIP`, `Snappy`, \u0026 `HADOOP_SNAPPY`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "errorOutputPrefix",
+          "type": "string",
+          "description": "(Optional) Prefix added to failed records before writing them to S3. Not currently supported for `redshift` destination. This prefix appears immediately following the bucket name. For information about how to specify this prefix, see [Custom Prefixes for Amazon S3 Objects](https://docs.aws.amazon.com/firehose/latest/dev/s3-prefixes.html).",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "kmsKeyArn",
+          "type": "string",
+          "description": "(Optional) Specifies the KMS key ARN the stream will use to encrypt data. If not set, no encryption will be used.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "prefix",
+          "type": "string",
+          "description": "(Optional) The \"YYYY/MM/DD/HH\" time format prefix is automatically used for delivered S3 files. You can specify an extra prefix to be added in front of the time format prefix. Note that if the prefix ends with a slash, it appears as a folder in the S3 bucket",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "roleArn",
+          "type": "string",
+          "description": "(Required) Kinesis Data Firehose uses this IAM role for all the permissions that the delivery stream needs. The pattern needs to be `arn:.*`.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "cloudwatchLoggingOptions",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "cloudwatchLoggingOptions",
+      "full_name": "RedshiftConfigurationS3ConfigurationCloudwatchLoggingOptions",
+      "arguments": [
+        {
+          "name": "enabled",
+          "type": "bool",
+          "description": "(Optional) Enables or disables the logging. Defaults to `false`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "logGroupName",
+          "type": "string",
+          "description": "(Optional) The CloudWatch group name for logging. This value is required if `enabled` is true.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "logStreamName",
+          "type": "string",
+          "description": "(Optional) The CloudWatch log stream name for logging. This value is required if `enabled` is true.",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "secretsManagerConfiguration",
+      "full_name": "RedshiftConfigurationSecretsManagerConfiguration",
+      "arguments": [
+        {
+          "name": "enabled",
+          "type": "bool",
+          "description": "(Optional) Enables or disables the Secrets Manager configuration.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "roleArn",
+          "type": "string",
+          "description": "(Optional) The ARN of the role the stream assumes.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "secretArn",
+          "type": "string",
+          "description": "(Optional) The ARN of the Secrets Manager secret. This value is required if `enabled` is true.",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "serverSideEncryption",
+      "full_name": "ServerSideEncryption",
+      "arguments": [
+        {
+          "name": "enabled",
+          "type": "bool",
+          "description": "(Optional) Whether to enable encryption at rest. Default is `false`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "keyArn",
+          "type": "string",
+          "description": "(Optional) Amazon Resource Name (ARN) of the encryption key. Required when `keyType` is `CUSTOMER_MANAGED_CMK`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "keyType",
+          "type": "string",
+          "description": "(Optional) Type of encryption key. Default is `AWS_OWNED_CMK`. Valid values are `AWS_OWNED_CMK` and `CUSTOMER_MANAGED_CMK`",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "snowflakeConfiguration",
+      "full_name": "SnowflakeConfiguration",
+      "arguments": [
+        {
+          "name": "accountUrl",
+          "type": "string",
+          "description": "(Required) The URL of the Snowflake account. Format: https://[account_identifier].snowflakecomputing.com.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "bufferingInterval",
+          "type": "number",
+          "description": "(Optional) Buffer incoming data for the specified period of time, in seconds between 0 to 900, before delivering it to the destination. The default value is 0s.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "bufferingSize",
+          "type": "number",
+          "description": "(Optional) Buffer incoming data to the specified size, in MBs between 1 to 128, before delivering it to the destination.  The default value is 1MB.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "contentColumnName",
+          "type": "string",
+          "description": "(Optional) The name of the content column.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "dataLoadingOption",
+          "type": "string",
+          "description": "(Optional) The data loading option.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "database",
+          "type": "string",
+          "description": "(Required) The Snowflake database name.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "keyPassphrase",
+          "type": "string",
+          "description": "(Optional) The passphrase for the private key.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "metadataColumnName",
+          "type": "string",
+          "description": "(Optional) The name of the metadata column.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "privateKey",
+          "type": "string",
+          "description": "(Optional) The private key for authentication. This value is required if `secretsManagerConfiguration` is not provided.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "retryDuration",
+          "type": "number",
+          "description": "(Optional) After an initial failure to deliver to Snowflake, the total amount of time, in seconds between 0 to 7200, during which Firehose re-attempts delivery (including the first attempt).  After this time has elapsed, the failed documents are written to Amazon S3.  The default value is 60s.  There will be no retry if the value is 0.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "roleArn",
+          "type": "string",
+          "description": "(Required) The ARN of the IAM role.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "s3BackupMode",
+          "type": "string",
+          "description": "(Optional) Defines how documents should be delivered to Amazon S3.  Valid values are `FailedDataOnly` and `AllData`.  Default value is `FailedDataOnly`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "schema",
+          "type": "string",
+          "description": "(Required) The Snowflake schema name.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "table",
+          "type": "string",
+          "description": "(Required) The Snowflake table name.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "user",
+          "type": "string",
+          "description": "(Optional) The user for authentication. This value is required if `secretsManagerConfiguration` is not provided.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "cloudwatchLoggingOptions",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "processingConfiguration",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "s3Configuration",
+          "type": "block",
+          "description": "",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "secretsManagerConfiguration",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "snowflakeRoleConfiguration",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "snowflakeVpcConfiguration",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "cloudwatchLoggingOptions",
+      "full_name": "SnowflakeConfigurationCloudwatchLoggingOptions",
+      "arguments": [
+        {
+          "name": "enabled",
+          "type": "bool",
+          "description": "(Optional) Enables or disables the logging. Defaults to `false`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "logGroupName",
+          "type": "string",
+          "description": "(Optional) The CloudWatch group name for logging. This value is required if `enabled` is true.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "logStreamName",
+          "type": "string",
+          "description": "(Optional) The CloudWatch log stream name for logging. This value is required if `enabled` is true.",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "processingConfiguration",
+      "full_name": "SnowflakeConfigurationProcessingConfiguration",
+      "arguments": [
+        {
+          "name": "enabled",
+          "type": "bool",
+          "description": "(Optional) Enables or disables data processing.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "processors",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "processors",
+      "full_name": "SnowflakeConfigurationProcessingConfigurationProcessors",
+      "arguments": [
+        {
+          "name": "type",
+          "type": "string",
+          "description": "(Required) The type of processor. Valid Values: `RecordDeAggregation`, `Lambda`, `MetadataExtraction`, `AppendDelimiterToRecord`, `Decompression`, `CloudWatchLogProcessing`. Validation is done against [AWS SDK constants](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/firehose/types#ProcessorType); so values not explicitly listed may also work.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "parameters",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "parameters",
+      "full_name": "SnowflakeConfigurationProcessingConfigurationProcessorsParameters",
+      "arguments": [
+        {
+          "name": "parameterName",
+          "type": "string",
+          "description": "(Required) Parameter name. Valid Values: `LambdaArn`, `NumberOfRetries`, `MetadataExtractionQuery`, `JsonParsingEngine`, `RoleArn`, `BufferSizeInMBs`, `BufferIntervalInSeconds`, `SubRecordType`, `Delimiter`, `CompressionFormat`, `DataMessageExtraction`. Validation is done against [AWS SDK constants](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/firehose/types#ProcessorParameterName); so values not explicitly listed may also work.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "parameterValue",
+          "type": "string",
+          "description": "(Required) Parameter value. Must be between 1 and 512 length (inclusive). When providing a Lambda ARN, you should specify the resource version as well.",
+          "required": true,
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "s3Configuration",
+      "full_name": "SnowflakeConfigurationS3Configuration",
+      "arguments": [
+        {
+          "name": "bucketArn",
+          "type": "string",
+          "description": "(Required) The ARN of the S3 bucket",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "bufferingInterval",
+          "type": "number",
+          "description": "(Optional) Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. The default value is 300 (5 minutes).",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "bufferingSize",
+          "type": "number",
+          "description": "(Optional) Buffer incoming data to the specified size, in MBs, before delivering it to the destination. The default value is 5.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "compressionFormat",
+          "type": "string",
+          "description": "(Optional) The compression format. If no value is specified, the default is `UNCOMPRESSED`. Other supported values are `GZIP`, `ZIP`, `Snappy`, \u0026 `HADOOP_SNAPPY`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "errorOutputPrefix",
+          "type": "string",
+          "description": "(Optional) Prefix added to failed records before writing them to S3. Not currently supported for `redshift` destination. This prefix appears immediately following the bucket name. For information about how to specify this prefix, see [Custom Prefixes for Amazon S3 Objects](https://docs.aws.amazon.com/firehose/latest/dev/s3-prefixes.html).",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "kmsKeyArn",
+          "type": "string",
+          "description": "(Optional) Specifies the KMS key ARN the stream will use to encrypt data. If not set, no encryption will be used.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "prefix",
+          "type": "string",
+          "description": "(Optional) The \"YYYY/MM/DD/HH\" time format prefix is automatically used for delivered S3 files. You can specify an extra prefix to be added in front of the time format prefix. Note that if the prefix ends with a slash, it appears as a folder in the S3 bucket",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "roleArn",
+          "type": "string",
+          "description": "(Required) Kinesis Data Firehose uses this IAM role for all the permissions that the delivery stream needs. The pattern needs to be `arn:.*`.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "cloudwatchLoggingOptions",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "cloudwatchLoggingOptions",
+      "full_name": "SnowflakeConfigurationS3ConfigurationCloudwatchLoggingOptions",
+      "arguments": [
+        {
+          "name": "enabled",
+          "type": "bool",
+          "description": "(Optional) Enables or disables the logging. Defaults to `false`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "logGroupName",
+          "type": "string",
+          "description": "(Optional) The CloudWatch group name for logging. This value is required if `enabled` is true.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "logStreamName",
+          "type": "string",
+          "description": "(Optional) The CloudWatch log stream name for logging. This value is required if `enabled` is true.",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "secretsManagerConfiguration",
+      "full_name": "SnowflakeConfigurationSecretsManagerConfiguration",
+      "arguments": [
+        {
+          "name": "enabled",
+          "type": "bool",
+          "description": "(Optional) Enables or disables the Secrets Manager configuration.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "roleArn",
+          "type": "string",
+          "description": "(Optional) The ARN of the role the stream assumes.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "secretArn",
+          "type": "string",
+          "description": "(Optional) The ARN of the Secrets Manager secret. This value is required if `enabled` is true.",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "snowflakeRoleConfiguration",
+      "full_name": "SnowflakeConfigurationSnowflakeRoleConfiguration",
+      "arguments": [
+        {
+          "name": "enabled",
+          "type": "bool",
+          "description": "(Optional) Whether the Snowflake role is enabled.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "snowflakeRole",
+          "type": "string",
+          "description": "(Optional) The Snowflake role.",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "snowflakeVpcConfiguration",
+      "full_name": "SnowflakeConfigurationSnowflakeVpcConfiguration",
+      "arguments": [
+        {
+          "name": "privateLinkVpceId",
+          "type": "string",
+          "description": "(Required) The VPCE ID for Firehose to privately connect with Snowflake.",
+          "required": true,
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "splunkConfiguration",
+      "full_name": "SplunkConfiguration",
+      "arguments": [
+        {
+          "name": "bufferingInterval",
+          "type": "number",
+          "description": "(Optional) Buffer incoming data for the specified period of time, in seconds between 0 to 60, before delivering it to the destination.  The default value is 60s.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "bufferingSize",
+          "type": "number",
+          "description": "(Optional) Buffer incoming data to the specified size, in MBs between 1 to 5, before delivering it to the destination.  The default value is 5MB.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "hecAcknowledgmentTimeout",
+          "type": "number",
+          "description": "(Optional) The amount of time, in seconds between 180 and 600, that Kinesis Firehose waits to receive an acknowledgment from Splunk after it sends it data.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "hecEndpoint",
+          "type": "string",
+          "description": "(Required) The HTTP Event Collector (HEC) endpoint to which Kinesis Firehose sends your data.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "hecEndpointType",
+          "type": "string",
+          "description": "(Optional) The HEC endpoint type. Valid values are `Raw` or `Event`. The default value is `Raw`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "hecToken",
+          "type": "string",
+          "description": "(Optional) The GUID that you obtain from your Splunk cluster when you create a new HEC endpoint. This value is required if `secretsManagerConfiguration` is not provided.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "retryDuration",
+          "type": "number",
+          "description": "(Optional) After an initial failure to deliver to Splunk, the total amount of time, in seconds between 0 to 7200, during which Firehose re-attempts delivery (including the first attempt).  After this time has elapsed, the failed documents are written to Amazon S3.  The default value is 300s.  There will be no retry if the value is 0.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "s3BackupMode",
+          "type": "string",
+          "description": "(Optional) Defines how documents should be delivered to Amazon S3.  Valid values are `FailedEventsOnly` and `AllEvents`.  Default value is `FailedEventsOnly`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "s3Configuration",
+          "type": "block",
+          "description": "",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "secretsManagerConfiguration",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "cloudwatchLoggingOptions",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "processingConfiguration",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "cloudwatchLoggingOptions",
+      "full_name": "SplunkConfigurationCloudwatchLoggingOptions",
+      "arguments": [
+        {
+          "name": "enabled",
+          "type": "bool",
+          "description": "(Optional) Enables or disables the logging. Defaults to `false`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "logGroupName",
+          "type": "string",
+          "description": "(Optional) The CloudWatch group name for logging. This value is required if `enabled` is true.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "logStreamName",
+          "type": "string",
+          "description": "(Optional) The CloudWatch log stream name for logging. This value is required if `enabled` is true.",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "processingConfiguration",
+      "full_name": "SplunkConfigurationProcessingConfiguration",
+      "arguments": [
+        {
+          "name": "enabled",
+          "type": "bool",
+          "description": "(Optional) Enables or disables data processing.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "processors",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "processors",
+      "full_name": "SplunkConfigurationProcessingConfigurationProcessors",
+      "arguments": [
+        {
+          "name": "type",
+          "type": "string",
+          "description": "(Required) The type of processor. Valid Values: `RecordDeAggregation`, `Lambda`, `MetadataExtraction`, `AppendDelimiterToRecord`, `Decompression`, `CloudWatchLogProcessing`. Validation is done against [AWS SDK constants](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/firehose/types#ProcessorType); so values not explicitly listed may also work.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "parameters",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "parameters",
+      "full_name": "SplunkConfigurationProcessingConfigurationProcessorsParameters",
+      "arguments": [
+        {
+          "name": "parameterName",
+          "type": "string",
+          "description": "(Required) Parameter name. Valid Values: `LambdaArn`, `NumberOfRetries`, `MetadataExtractionQuery`, `JsonParsingEngine`, `RoleArn`, `BufferSizeInMBs`, `BufferIntervalInSeconds`, `SubRecordType`, `Delimiter`, `CompressionFormat`, `DataMessageExtraction`. Validation is done against [AWS SDK constants](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/firehose/types#ProcessorParameterName); so values not explicitly listed may also work.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "parameterValue",
+          "type": "string",
+          "description": "(Required) Parameter value. Must be between 1 and 512 length (inclusive). When providing a Lambda ARN, you should specify the resource version as well.",
+          "required": true,
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "s3Configuration",
+      "full_name": "SplunkConfigurationS3Configuration",
+      "arguments": [
+        {
+          "name": "bucketArn",
+          "type": "string",
+          "description": "(Required) The ARN of the S3 bucket",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "bufferingInterval",
+          "type": "number",
+          "description": "(Optional) Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. The default value is 300 (5 minutes).",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "bufferingSize",
+          "type": "number",
+          "description": "(Optional) Buffer incoming data to the specified size, in MBs, before delivering it to the destination. The default value is 5.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "compressionFormat",
+          "type": "string",
+          "description": "(Optional) The compression format. If no value is specified, the default is `UNCOMPRESSED`. Other supported values are `GZIP`, `ZIP`, `Snappy`, \u0026 `HADOOP_SNAPPY`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "errorOutputPrefix",
+          "type": "string",
+          "description": "(Optional) Prefix added to failed records before writing them to S3. Not currently supported for `redshift` destination. This prefix appears immediately following the bucket name. For information about how to specify this prefix, see [Custom Prefixes for Amazon S3 Objects](https://docs.aws.amazon.com/firehose/latest/dev/s3-prefixes.html).",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "kmsKeyArn",
+          "type": "string",
+          "description": "(Optional) Specifies the KMS key ARN the stream will use to encrypt data. If not set, no encryption will be used.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "prefix",
+          "type": "string",
+          "description": "(Optional) The \"YYYY/MM/DD/HH\" time format prefix is automatically used for delivered S3 files. You can specify an extra prefix to be added in front of the time format prefix. Note that if the prefix ends with a slash, it appears as a folder in the S3 bucket",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "roleArn",
+          "type": "string",
+          "description": "(Required) Kinesis Data Firehose uses this IAM role for all the permissions that the delivery stream needs. The pattern needs to be `arn:.*`.",
+          "required": true,
+          "optional": false
+        },
+        {
+          "name": "cloudwatchLoggingOptions",
+          "type": "block",
+          "description": "",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "cloudwatchLoggingOptions",
+      "full_name": "SplunkConfigurationS3ConfigurationCloudwatchLoggingOptions",
+      "arguments": [
+        {
+          "name": "enabled",
+          "type": "bool",
+          "description": "(Optional) Enables or disables the logging. Defaults to `false`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "logGroupName",
+          "type": "string",
+          "description": "(Optional) The CloudWatch group name for logging. This value is required if `enabled` is true.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "logStreamName",
+          "type": "string",
+          "description": "(Optional) The CloudWatch log stream name for logging. This value is required if `enabled` is true.",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "secretsManagerConfiguration",
+      "full_name": "SplunkConfigurationSecretsManagerConfiguration",
+      "arguments": [
+        {
+          "name": "enabled",
+          "type": "bool",
+          "description": "(Optional) Enables or disables the Secrets Manager configuration.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "roleArn",
+          "type": "string",
+          "description": "(Optional) The ARN of the role the stream assumes.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "secretArn",
+          "type": "string",
+          "description": "(Optional) The ARN of the Secrets Manager secret. This value is required if `enabled` is true.",
+          "required": false,
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "timeouts",
+      "full_name": "Timeouts",
+      "arguments": [
+        {
+          "name": "create",
+          "type": "string",
+          "description": "(Default `30m`)",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "delete",
+          "type": "string",
+          "description": "(Default `30m`)",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "update",
+          "type": "string",
+          "description": "(Default `10m`)",
+          "required": false,
+          "optional": true
+        }
+      ]
+    }
+  ]
+}

--- a/data/reference/docs/typescript/provider-aws/r/rds_cluster.json
+++ b/data/reference/docs/typescript/provider-aws/r/rds_cluster.json
@@ -1,669 +1,713 @@
 {
   "arguments": [
     {
-      "name": "performanceInsightsRetentionPeriod",
-      "type": "number",
-      "description": "(Optional) Specifies the amount of time to retain performance insights data for. Defaults to 7 days if Performance Insights are enabled. Valid values are `7`, `month * 31` (where month is a number of months from 1-23), and `731`. See [here](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PerfInsights.Overview.cost.html) for more information on retention periods.",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "applyImmediately",
-      "type": "bool",
-      "description": "(Optional) Specifies whether any cluster modifications are applied immediately, or during the next maintenance window. Default is `false`. See [Amazon RDS Documentation for more information.](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.DBInstance.Modifying.html)",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "copyTagsToSnapshot",
-      "type": "bool",
-      "description": "(Optional, boolean) Copy all Cluster `tags` to snapshots. Default is `false`.",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "enabledCloudwatchLogsExports",
-      "type": "set",
-      "description": "(Optional) Set of log types to export to cloudwatch. If omitted, no logs will be exported. The following log types are supported: `audit`, `error`, `general`, `slowquery`, `iam-db-auth-error`, `postgresql` (PostgreSQL).",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "kmsKeyId",
-      "type": "string",
-      "description": "(Optional) ARN for the KMS encryption key. When specifying `kmsKeyId`, `storageEncrypted` needs to be set to true.",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "sourceRegion",
-      "type": "string",
-      "description": "(Optional) The source region for an encrypted replica DB cluster.",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "tags",
-      "type": "map",
-      "description": "(Optional) A map of tags to assign to the DB cluster. If configured with a provider [`defaultTags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "deleteAutomatedBackups",
-      "type": "bool",
-      "description": "(Optional) Specifies whether to remove automated backups immediately after the DB cluster is deleted. Default is `true`.",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "iamRoles",
-      "type": "set",
-      "description": "(Optional) List of ARNs for the IAM roles to associate to the RDS Cluster.",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "dbSubnetGroupName",
-      "type": "string",
-      "description": "(Optional) DB subnet group to associate with this DB cluster.",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "enableHttpEndpoint",
-      "type": "bool",
-      "description": "(Optional) Enable HTTP endpoint (data API). Only valid for some combinations of `engineMode`, `engine` and `engineVersion` and only available in some regions. See the [Region and version availability](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/data-api.html#data-api.regions) section of the documentation. This option also does not work with any of these options specified: `snapshotIdentifier`, `replicationSourceIdentifier`, `s3Import`.",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "storageEncrypted",
-      "type": "bool",
-      "description": "(Optional) Specifies whether the DB cluster is encrypted. The default is `false` for `provisioned` `engineMode` and `true` for `serverless` `engineMode`. When restoring an unencrypted `snapshotIdentifier`, the `kmsKeyId` argument must be provided to encrypt the restored cluster. Terraform will only perform drift detection if a configuration value is provided.",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "dbSystemId",
-      "type": "string",
-      "description": "(Optional) For use with RDS Custom.",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "monitoringInterval",
-      "type": "number",
-      "description": "(Optional) Interval, in seconds, in seconds, between points when Enhanced Monitoring metrics are collected for the DB cluster. To turn off collecting Enhanced Monitoring metrics, specify 0. The default is 0. Valid Values: 0, 1, 5, 10, 15, 30, 60.",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "performanceInsightsEnabled",
-      "type": "bool",
-      "description": "(Optional) Enables Performance Insights.",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "dbInstanceParameterGroupName",
-      "type": "string",
-      "description": "(Optional) Instance parameter group to associate with all instances of the DB cluster. The `dbInstanceParameterGroupName` parameter is only valid in combination with the `allowMajorVersionUpgrade` parameter.",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "iops",
-      "type": "number",
-      "description": "(Optional) Amount of Provisioned IOPS (input/output operations per second) to be initially allocated for each DB instance in the Multi-AZ DB cluster. For information about valid Iops values, see [Amazon RDS Provisioned IOPS storage to improve performance](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Storage.html#USER_PIOPS) in the Amazon RDS User Guide. (This setting is required to create a Multi-AZ DB cluster). Must be a multiple between .5 and 50 of the storage amount for the DB cluster.",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "masterUsername",
-      "type": "string",
-      "description": "(Required unless a `snapshotIdentifier` or `replicationSourceIdentifier` is provided or unless a `globalClusterIdentifier` is provided when the cluster is the \"secondary\" cluster of a global database) Username for the master DB user. Please refer to the [RDS Naming Constraints][5]. This argument does not support in-place updates and cannot be changed during a restore from snapshot.",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "networkType",
-      "type": "string",
-      "description": "(Optional) Network type of the cluster. Valid values: `IPV4`, `DUAL`.",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "backupRetentionPeriod",
-      "type": "number",
-      "description": "(Optional) Days to retain backups for. Default `1`",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "enableGlobalWriteForwarding",
-      "type": "bool",
-      "description": "(Optional) Whether cluster should forward writes to an associated global cluster. Applied to secondary clusters to enable them to forward writes to an [`aws_rds_global_cluster`](/docs/providers/aws/r/rds_global_cluster.html)'s primary cluster. See the [User Guide for Aurora](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-global-database-write-forwarding.html) for more information.",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "manageMasterUserPassword",
-      "type": "bool",
-      "description": "(Optional) Set to true to allow RDS to manage the master user password in Secrets Manager. Cannot be set if `masterPassword` is provided.",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "availabilityZones",
-      "type": "set",
-      "description": "(Optional) List of EC2 Availability Zones for the DB cluster storage where DB cluster instances can be created.",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "backtrackWindow",
-      "type": "number",
-      "description": "(Optional) Target backtrack window, in seconds. Only available for `aurora` and `aurora-mysql` engines currently. To disable backtracking, set this value to `0`. Defaults to `0`. Must be between `0` and `259200` (72 hours)",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "domainIamRoleName",
-      "type": "string",
-      "description": "(Optional, but required if `domain` is provided) The name of the IAM role to be used when making API calls to the Directory Service.",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "monitoringRoleArn",
-      "type": "string",
-      "description": "(Optional) ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. You can find more information on the [AWS Documentation](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Monitoring.html#USER_Monitoring.OS.IAMRole.html) what IAM permissions are needed to allow Enhanced Monitoring for RDS Clusters.",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "port",
-      "type": "number",
-      "description": "(Optional) Port on which the DB accepts connections.",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "clusterIdentifierPrefix",
-      "type": "string",
-      "description": "(Optional, Forces new resource) Creates a unique cluster identifier beginning with the specified prefix. Conflicts with `clusterIdentifier`.",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "storageType",
-      "type": "string",
-      "description": "(Optional, Required for Multi-AZ DB cluster) (Forces new for Multi-AZ DB clusters) Specifies the storage type to be associated with the DB cluster. For Aurora DB clusters, `storageType` modifications can be done in-place. For Multi-AZ DB Clusters, the `iops` argument must also be set. Valid values are: `\"\"`, `aurora-iopt1` (Aurora DB Clusters); `io1`, `io2` (Multi-AZ DB Clusters). Default: `\"\"` (Aurora DB Clusters); `io1` (Multi-AZ DB Clusters).",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "vpcSecurityGroupIds",
-      "type": "set",
-      "description": "(Optional) List of VPC security groups to associate with the Cluster",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "enableLocalWriteForwarding",
-      "type": "bool",
-      "description": "(Optional) Whether read replicas can forward write operations to the writer DB instance in the DB cluster. By default, write operations aren't allowed on reader DB instances.. See the [User Guide for Aurora](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-mysql-write-forwarding.html) for more information. **NOTE:** Local write forwarding requires Aurora MySQL version 3.04 or higher.",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "preferredBackupWindow",
-      "type": "string",
-      "description": "(Optional) Daily time range during which automated backups are created if automated backups are enabled using the BackupRetentionPeriod parameter.Time in UTC. Default: A 30-minute window selected at random from an 8-hour block of time per region, e.g. `04:00-09:00`.",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "dbClusterInstanceClass",
-      "type": "string",
-      "description": "(Optional, Required for Multi-AZ DB cluster) The compute and memory capacity of each DB instance in the Multi-AZ DB cluster, for example `db.m6g.xlarge`. Not all DB instance classes are available in all AWS Regions, or for all database engines. For the full list of DB instance classes and availability for your engine, see [DB instance class](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.html) in the Amazon RDS User Guide.",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "deletionProtection",
-      "type": "bool",
-      "description": "(Optional) If the DB cluster should have deletion protection enabled.",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "iamDatabaseAuthenticationEnabled",
-      "type": "bool",
-      "description": "(Optional) Specifies whether or not mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled. Please see [AWS Documentation](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/UsingWithRDS.IAMDBAuth.html) for availability and limitations.",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "preferredMaintenanceWindow",
-      "type": "string",
-      "description": "(Optional) Weekly time range during which system maintenance can occur, in (UTC) e.g., `wed:04:00-wed:04:30`",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "clusterIdentifier",
-      "type": "string",
-      "description": "(Optional, Forces new resources) The cluster identifier. If omitted, Terraform will assign a random, unique identifier.",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
       "name": "allocatedStorage",
       "type": "number",
       "description": "(Optional, Required for Multi-AZ DB cluster) The amount of storage in gibibytes (GiB) to allocate to each DB instance in the Multi-AZ DB cluster.",
       "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "engineLifecycleSupport",
-      "type": "string",
-      "description": "(Optional) The life cycle type for this DB instance. This setting is valid for cluster types Aurora DB clusters and Multi-AZ DB clusters. Valid values are `open-source-rds-extended-support`, `open-source-rds-extended-support-disabled`. Default value is `open-source-rds-extended-support`. [Using Amazon RDS Extended Support]: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/extended-support.html",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "engineMode",
-      "type": "string",
-      "description": "(Optional) Database engine mode. Valid values: `global` (only valid for Aurora MySQL 1.21 and earlier), `parallelquery`, `provisioned`, `serverless`. Defaults to: `provisioned`. See the [RDS User Guide](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless.html) for limitations when using `serverless`.",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "globalClusterIdentifier",
-      "type": "string",
-      "description": "(Optional) Global cluster identifier specified on [`aws_rds_global_cluster`](/docs/providers/aws/r/rds_global_cluster.html).",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "masterPassword",
-      "type": "string",
-      "description": "(Required unless `manageMasterUserPassword` is set to true or unless a `snapshotIdentifier` or `replicationSourceIdentifier` is provided or unless a `globalClusterIdentifier` is provided when the cluster is the \"secondary\" cluster of a global database) Password for the master DB user. Note that this may show up in logs, and it will be stored in the state file. Please refer to the [RDS Naming Constraints][5]. Cannot be set if `manageMasterUserPassword` is set to `true`.",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "masterUserSecretKmsKeyId",
-      "type": "string",
-      "description": "(Optional) Amazon Web Services KMS key identifier is the key ARN, key ID, alias ARN, or alias name for the KMS key. To use a KMS key in a different Amazon Web Services account, specify the key ARN or alias ARN. If not specified, the default KMS key for your Amazon Web Services account is used.",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "caCertificateIdentifier",
-      "type": "string",
-      "description": "(Optional) The CA certificate identifier to use for the DB cluster's server certificate.",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "databaseName",
-      "type": "string",
-      "description": "(Optional) Name for an automatically created database on cluster creation. There are different naming restrictions per database engine: [RDS Naming Constraints][5]",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "snapshotIdentifier",
-      "type": "string",
-      "description": "(Optional) Specifies whether or not to create this cluster from a snapshot. You can use either the name or ARN when specifying a DB cluster snapshot, or the ARN when specifying a DB snapshot. Conflicts with `globalClusterIdentifier`. Clusters cannot be restored from snapshot **and** joined to an existing global cluster in a single operation. See the [AWS documentation](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-global-database-getting-started.html#aurora-global-database.use-snapshot) or the [Global Cluster Restored From Snapshot example](#global-cluster-restored-from-snapshot) for instructions on building a global cluster starting with a snapshot.",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "domain",
-      "type": "string",
-      "description": "(Optional) The ID of the Directory Service Active Directory domain to create the cluster in.",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "replicationSourceIdentifier",
-      "type": "string",
-      "description": "(Optional) ARN of a source DB cluster or DB instance if this DB cluster is to be created as a Read Replica. **Note:** Removing this attribute after creation will promote the read replica to a standalone cluster. If DB Cluster is part of a Global Cluster, use the [`lifecycle` configuration block `ignore_changes` argument](https://www.terraform.io/docs/configuration/meta-arguments/lifecycle.html#ignore_changes) to prevent Terraform from showing differences for this argument instead of configuring this value.",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "skipFinalSnapshot",
-      "type": "bool",
-      "description": "(Optional) Determines whether a final DB snapshot is created before the DB cluster is deleted. If true is specified, no DB snapshot is created. If false is specified, a DB snapshot is created before the DB cluster is deleted, using the value from `finalSnapshotIdentifier`. Default is `false`.",
-      "required": false,
-      "optional": true,
-      "level": 0
+      "optional": true
     },
     {
       "name": "allowMajorVersionUpgrade",
       "type": "bool",
       "description": "(Optional) Enable to allow major engine version upgrades when changing engine versions. Defaults to `false`.",
       "required": false,
-      "optional": true,
-      "level": 0
+      "optional": true
+    },
+    {
+      "name": "applyImmediately",
+      "type": "bool",
+      "description": "(Optional) Specifies whether any cluster modifications are applied immediately, or during the next maintenance window. Default is `false`. See [Amazon RDS Documentation for more information.](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.DBInstance.Modifying.html)",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "arn",
+      "type": "string",
+      "description": "",
+      "required": false,
+      "optional": false
+    },
+    {
+      "name": "availabilityZones",
+      "type": "set",
+      "description": "(Optional) List of EC2 Availability Zones for the DB cluster storage where DB cluster instances can be created.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "backtrackWindow",
+      "type": "number",
+      "description": "(Optional) Target backtrack window, in seconds. Only available for `aurora` and `aurora-mysql` engines currently. To disable backtracking, set this value to `0`. Defaults to `0`. Must be between `0` and `259200` (72 hours)",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "backupRetentionPeriod",
+      "type": "number",
+      "description": "(Optional) Days to retain backups for. Default `1`",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "caCertificateIdentifier",
+      "type": "string",
+      "description": "(Optional) The CA certificate identifier to use for the DB cluster's server certificate.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "caCertificateValidTill",
+      "type": "string",
+      "description": "",
+      "required": false,
+      "optional": false
+    },
+    {
+      "name": "clusterIdentifier",
+      "type": "string",
+      "description": "(Optional, Forces new resources) The cluster identifier. If omitted, Terraform will assign a random, unique identifier.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "clusterIdentifierPrefix",
+      "type": "string",
+      "description": "(Optional, Forces new resource) Creates a unique cluster identifier beginning with the specified prefix. Conflicts with `clusterIdentifier`.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "clusterMembers",
+      "type": "set",
+      "description": "",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "clusterResourceId",
+      "type": "string",
+      "description": "",
+      "required": false,
+      "optional": false
+    },
+    {
+      "name": "clusterScalabilityType",
+      "type": "string",
+      "description": "(Optional, Forces new resources) Specifies the scalability mode of the Aurora DB cluster. When set to `limitless`, the cluster operates as an Aurora Limitless Database. When set to `standard` (the default), the cluster uses normal DB instance creation. Valid values: `limitless`, `standard`.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "copyTagsToSnapshot",
+      "type": "bool",
+      "description": "(Optional, boolean) Copy all Cluster `tags` to snapshots. Default is `false`.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "databaseInsightsMode",
+      "type": "string",
+      "description": "(Optional) The mode of Database Insights to enable for the DB cluster. Valid values: `standard`, `advanced`.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "databaseName",
+      "type": "string",
+      "description": "(Optional) Name for an automatically created database on cluster creation. There are different naming restrictions per database engine: [RDS Naming Constraints][5]",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "dbClusterInstanceClass",
+      "type": "string",
+      "description": "(Optional, Required for Multi-AZ DB cluster) The compute and memory capacity of each DB instance in the Multi-AZ DB cluster, for example `db.m6g.xlarge`. Not all DB instance classes are available in all AWS Regions, or for all database engines. For the full list of DB instance classes and availability for your engine, see [DB instance class](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.html) in the Amazon RDS User Guide.",
+      "required": false,
+      "optional": true
     },
     {
       "name": "dbClusterParameterGroupName",
       "type": "string",
       "description": "(Optional) A cluster parameter group to associate with the cluster.",
       "required": false,
-      "optional": true,
-      "level": 0
+      "optional": true
+    },
+    {
+      "name": "dbInstanceParameterGroupName",
+      "type": "string",
+      "description": "(Optional) Instance parameter group to associate with all instances of the DB cluster. The `dbInstanceParameterGroupName` parameter is only valid in combination with the `allowMajorVersionUpgrade` parameter.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "dbSubnetGroupName",
+      "type": "string",
+      "description": "(Optional) DB subnet group to associate with this DB cluster.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "dbSystemId",
+      "type": "string",
+      "description": "(Optional) For use with RDS Custom.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "deleteAutomatedBackups",
+      "type": "bool",
+      "description": "(Optional) Specifies whether to remove automated backups immediately after the DB cluster is deleted. Default is `true`.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "deletionProtection",
+      "type": "bool",
+      "description": "(Optional) If the DB cluster should have deletion protection enabled.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "domain",
+      "type": "string",
+      "description": "(Optional) The ID of the Directory Service Active Directory domain to create the cluster in.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "domainIamRoleName",
+      "type": "string",
+      "description": "(Optional, but required if `domain` is provided) The name of the IAM role to be used when making API calls to the Directory Service.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "enableGlobalWriteForwarding",
+      "type": "bool",
+      "description": "(Optional) Whether cluster should forward writes to an associated global cluster. Applied to secondary clusters to enable them to forward writes to an [`aws_rds_global_cluster`](/docs/providers/aws/r/rds_global_cluster.html)'s primary cluster. See the [User Guide for Aurora](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-global-database-write-forwarding.html) for more information.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "enableHttpEndpoint",
+      "type": "bool",
+      "description": "(Optional) Enable HTTP endpoint (data API). Only valid for some combinations of `engineMode`, `engine` and `engineVersion` and only available in some regions. See the [Region and version availability](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/data-api.html#data-api.regions) section of the documentation. This option also does not work with any of these options specified: `snapshotIdentifier`, `replicationSourceIdentifier`, `s3Import`.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "enableLocalWriteForwarding",
+      "type": "bool",
+      "description": "(Optional) Whether read replicas can forward write operations to the writer DB instance in the DB cluster. By default, write operations aren't allowed on reader DB instances.. See the [User Guide for Aurora](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-mysql-write-forwarding.html) for more information. **NOTE:** Local write forwarding requires Aurora MySQL version 3.04 or higher.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "enabledCloudwatchLogsExports",
+      "type": "set",
+      "description": "(Optional) Set of log types to export to cloudwatch. If omitted, no logs will be exported. The following log types are supported: `audit`, `error`, `general`, `slowquery`, `iam-db-auth-error`, `postgresql` (PostgreSQL).",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "endpoint",
+      "type": "string",
+      "description": "",
+      "required": false,
+      "optional": false
     },
     {
       "name": "engine",
       "type": "string",
       "description": "(Required) Name of the database engine to be used for this DB cluster. Valid Values: `aurora-mysql`, `aurora-postgresql`, `mysql`, `postgres`. (Note that `mysql` and `postgres` are Multi-AZ RDS clusters).",
       "required": true,
-      "optional": false,
-      "level": 0
+      "optional": false
+    },
+    {
+      "name": "engineLifecycleSupport",
+      "type": "string",
+      "description": "(Optional) The life cycle type for this DB instance. This setting is valid for cluster types Aurora DB clusters and Multi-AZ DB clusters. Valid values are `open-source-rds-extended-support`, `open-source-rds-extended-support-disabled`. Default value is `open-source-rds-extended-support`. [Using Amazon RDS Extended Support]: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/extended-support.html",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "engineMode",
+      "type": "string",
+      "description": "(Optional) Database engine mode. Valid values: `global` (only valid for Aurora MySQL 1.21 and earlier), `parallelquery`, `provisioned`, `serverless`. Defaults to: `provisioned`. Specify an empty value (`\"\"`) for no engine mode. See the [RDS User Guide](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless.html) for limitations when using `serverless`.",
+      "required": false,
+      "optional": true
     },
     {
       "name": "engineVersion",
       "type": "string",
       "description": "(Optional) Database engine version. Updating this argument results in an outage. See the [Aurora MySQL](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Updates.html) and [Aurora Postgres](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Updates.html) documentation for your configured engine to determine this value, or by running `aws rds describe-db-engine-versions`. For example with Aurora MySQL 2, a potential value for this argument is `5.7.mysql_aurora.2.03.2`. The value can contain a partial version where supported by the API. The actual engine version used is returned in the attribute `engineVersionActual`, , see [Attribute Reference](#attribute-reference) below.",
       "required": false,
-      "optional": true,
-      "level": 0
+      "optional": true
+    },
+    {
+      "name": "engineVersionActual",
+      "type": "string",
+      "description": "",
+      "required": false,
+      "optional": false
     },
     {
       "name": "finalSnapshotIdentifier",
       "type": "string",
       "description": "(Optional) Name of your final DB snapshot when this DB cluster is deleted. If omitted, no final snapshot will be made.",
       "required": false,
-      "optional": true,
-      "level": 0
+      "optional": true
+    },
+    {
+      "name": "globalClusterIdentifier",
+      "type": "string",
+      "description": "(Optional) Global cluster identifier specified on [`aws_rds_global_cluster`](/docs/providers/aws/r/rds_global_cluster.html).",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "hostedZoneId",
+      "type": "string",
+      "description": "",
+      "required": false,
+      "optional": false
+    },
+    {
+      "name": "iamDatabaseAuthenticationEnabled",
+      "type": "bool",
+      "description": "(Optional) Specifies whether or not mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled. Please see [AWS Documentation](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/UsingWithRDS.IAMDBAuth.html) for availability and limitations.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "iamRoles",
+      "type": "set",
+      "description": "(Optional) List of ARNs for the IAM roles to associate to the RDS Cluster.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "id",
+      "type": "string",
+      "description": "",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "iops",
+      "type": "number",
+      "description": "(Optional) Amount of Provisioned IOPS (input/output operations per second) to be initially allocated for each DB instance in the Multi-AZ DB cluster. For information about valid Iops values, see [Amazon RDS Provisioned IOPS storage to improve performance](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Storage.html#USER_PIOPS) in the Amazon RDS User Guide. (This setting is required to create a Multi-AZ DB cluster). Must be a multiple between .5 and 50 of the storage amount for the DB cluster.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "kmsKeyId",
+      "type": "string",
+      "description": "(Optional) ARN for the KMS encryption key. When specifying `kmsKeyId`, `storageEncrypted` needs to be set to true.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "manageMasterUserPassword",
+      "type": "bool",
+      "description": "(Optional) Set to true to allow RDS to manage the master user password in Secrets Manager. Cannot be set if `masterPassword` is provided.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "masterPassword",
+      "type": "string",
+      "description": "(Optional, required unless `manageMasterUserPassword` is set to true, a `snapshotIdentifier`, `replicationSourceIdentifier`, or `masterPasswordWo` is provided or unless a `globalClusterIdentifier` is provided when the cluster is the \"secondary\" cluster of a global database) Password for the master DB user. Note that this may show up in logs, and it will be stored in the state file. Please refer to the [RDS Naming Constraints][5]. Cannot be set if `manageMasterUserPassword` is set to `true`.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "masterPasswordWo",
+      "type": "string",
+      "description": "",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "masterPasswordWoVersion",
+      "type": "number",
+      "description": "(Optional) Used together with `masterPasswordWo` to trigger an update. Increment this value when an update to the `masterPasswordWo` is required.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "masterUserSecret",
+      "type": "list",
+      "description": "",
+      "required": false,
+      "optional": false
+    },
+    {
+      "name": "masterUserSecretKmsKeyId",
+      "type": "string",
+      "description": "(Optional) Amazon Web Services KMS key identifier is the key ARN, key ID, alias ARN, or alias name for the KMS key. To use a KMS key in a different Amazon Web Services account, specify the key ARN or alias ARN. If not specified, the default KMS key for your Amazon Web Services account is used.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "masterUsername",
+      "type": "string",
+      "description": "(Required unless a `snapshotIdentifier` or `replicationSourceIdentifier` is provided or unless a `globalClusterIdentifier` is provided when the cluster is the \"secondary\" cluster of a global database) Username for the master DB user. Please refer to the [RDS Naming Constraints][5]. This argument does not support in-place updates and cannot be changed during a restore from snapshot.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "monitoringInterval",
+      "type": "number",
+      "description": "(Optional) Interval, in seconds, in seconds, between points when Enhanced Monitoring metrics are collected for the DB cluster. To turn off collecting Enhanced Monitoring metrics, specify 0. The default is 0. Valid Values: 0, 1, 5, 10, 15, 30, 60.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "monitoringRoleArn",
+      "type": "string",
+      "description": "(Optional) ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. You can find more information on the [AWS Documentation](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Monitoring.html#USER_Monitoring.OS.IAMRole.html) what IAM permissions are needed to allow Enhanced Monitoring for RDS Clusters.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "networkType",
+      "type": "string",
+      "description": "(Optional) Network type of the cluster. Valid values: `IPV4`, `DUAL`.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "performanceInsightsEnabled",
+      "type": "bool",
+      "description": "(Optional) Enables Performance Insights.",
+      "required": false,
+      "optional": true
     },
     {
       "name": "performanceInsightsKmsKeyId",
       "type": "string",
       "description": "(Optional) Specifies the KMS Key ID to encrypt Performance Insights data. If not specified, the default RDS KMS key will be used (`aws/rds`).",
       "required": false,
-      "optional": true,
-      "level": 0
+      "optional": true
+    },
+    {
+      "name": "performanceInsightsRetentionPeriod",
+      "type": "number",
+      "description": "(Optional) Specifies the amount of time to retain performance insights data for. Defaults to 7 days if Performance Insights are enabled. Valid values are `7`, `month * 31` (where month is a number of months from 1-23), and `731`. See [here](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PerfInsights.Overview.cost.html) for more information on retention periods.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "port",
+      "type": "number",
+      "description": "(Optional) Port on which the DB accepts connections.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "preferredBackupWindow",
+      "type": "string",
+      "description": "(Optional) Daily time range during which automated backups are created if automated backups are enabled using the BackupRetentionPeriod parameter.Time in UTC. Default: A 30-minute window selected at random from an 8-hour block of time per region, e.g. `04:00-09:00`.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "preferredMaintenanceWindow",
+      "type": "string",
+      "description": "(Optional) Weekly time range during which system maintenance can occur, in (UTC) e.g., `wed:04:00-wed:04:30`",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "readerEndpoint",
+      "type": "string",
+      "description": "",
+      "required": false,
+      "optional": false
+    },
+    {
+      "name": "replicationSourceIdentifier",
+      "type": "string",
+      "description": "(Optional) ARN of a source DB cluster or DB instance if this DB cluster is to be created as a Read Replica. **Note:** Removing this attribute after creation will promote the read replica to a standalone cluster. If DB Cluster is part of a Global Cluster, use the [`lifecycle` configuration block `ignore_changes` argument](https://www.terraform.io/docs/configuration/meta-arguments/lifecycle.html#ignore_changes) to prevent Terraform from showing differences for this argument instead of configuring this value.",
+      "required": false,
+      "optional": true
     },
     {
       "name": "restoreToPointInTime",
       "type": "block",
-      "description": "(Optional) Nested attribute for [point in time restore](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-pitr.html). More details below.",
+      "description": "",
       "required": false,
-      "optional": true,
-      "level": 0
+      "optional": true
+    },
+    {
+      "name": "s3Import",
+      "type": "block",
+      "description": "",
+      "required": false,
+      "optional": true
     },
     {
       "name": "scalingConfiguration",
       "type": "block",
-      "description": "(Optional) Nested attribute with scaling properties. Only valid when `engineMode` is set to `serverless`. More details below.",
+      "description": "",
       "required": false,
-      "optional": true,
-      "level": 0
+      "optional": true
     },
     {
       "name": "serverlessv2ScalingConfiguration",
       "type": "block",
-      "description": "(Optional) Nested attribute with scaling properties for ServerlessV2. Only valid when `engineMode` is set to `provisioned`. More details below.",
+      "description": "",
       "required": false,
-      "optional": true,
-      "level": 0
+      "optional": true
+    },
+    {
+      "name": "skipFinalSnapshot",
+      "type": "bool",
+      "description": "(Optional) Determines whether a final DB snapshot is created before the DB cluster is deleted. If true is specified, no DB snapshot is created. If false is specified, a DB snapshot is created before the DB cluster is deleted, using the value from `finalSnapshotIdentifier`. Default is `false`.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "snapshotIdentifier",
+      "type": "string",
+      "description": "(Optional) Specifies whether or not to create this cluster from a snapshot. You can use either the name or ARN when specifying a DB cluster snapshot, or the ARN when specifying a DB snapshot. Conflicts with `globalClusterIdentifier`. Clusters cannot be restored from snapshot **and** joined to an existing global cluster in a single operation. See the [AWS documentation](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-global-database-getting-started.html#aurora-global-database.use-snapshot) or the [Global Cluster Restored From Snapshot example](#global-cluster-restored-from-snapshot) for instructions on building a global cluster starting with a snapshot.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "sourceRegion",
+      "type": "string",
+      "description": "(Optional) The source region for an encrypted replica DB cluster.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "storageEncrypted",
+      "type": "bool",
+      "description": "(Optional) Specifies whether the DB cluster is encrypted. The default is `false` for `provisioned` `engineMode` and `true` for `serverless` `engineMode`. When restoring an unencrypted `snapshotIdentifier`, the `kmsKeyId` argument must be provided to encrypt the restored cluster. Terraform will only perform drift detection if a configuration value is provided.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "storageType",
+      "type": "string",
+      "description": "(Optional, Required for Multi-AZ DB cluster) (Forces new for Multi-AZ DB clusters) Specifies the storage type to be associated with the DB cluster. For Aurora DB clusters, `storageType` modifications can be done in-place. For Multi-AZ DB Clusters, the `iops` argument must also be set. Valid values are: `\"\"`, `aurora-iopt1` (Aurora DB Clusters); `io1`, `io2` (Multi-AZ DB Clusters). Default: `\"\"` (Aurora DB Clusters); `io1` (Multi-AZ DB Clusters).",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "tags",
+      "type": "map",
+      "description": "(Optional) A map of tags to assign to the DB cluster. If configured with a provider [`defaultTags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "tagsAll",
+      "type": "map",
+      "description": "",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "timeouts",
+      "type": "block",
+      "description": "",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "vpcSecurityGroupIds",
+      "type": "set",
+      "description": "(Optional) List of VPC security groups to associate with the Cluster For more detailed documentation about each argument, refer to the AWS official documentation:",
+      "required": false,
+      "optional": true
     }
   ],
   "blocks": [
     {
       "name": "restoreToPointInTime",
+      "full_name": "RestoreToPointInTime",
       "arguments": [
-        {
-          "name": "useLatestRestorableTime",
-          "type": "bool",
-          "description": "(Optional) Set to true to restore the database cluster to the latest restorable backup time. Defaults to false. Conflicts with `restoreToTime`.",
-          "required": false,
-          "optional": true,
-          "level": 0
-        },
         {
           "name": "restoreToTime",
           "type": "string",
           "description": "(Optional) Date and time in UTC format to restore the database cluster to. Conflicts with `useLatestRestorableTime`.",
           "required": false,
-          "optional": true,
-          "level": 0
+          "optional": true
         },
         {
           "name": "restoreType",
           "type": "string",
           "description": "(Optional) Type of restore to be performed.",
           "required": false,
-          "optional": true,
-          "level": 0
+          "optional": true
         },
         {
           "name": "sourceClusterIdentifier",
           "type": "string",
           "description": "(Optional) Identifier of the source database cluster from which to restore. When restoring from a cluster in another AWS account, the identifier is the ARN of that cluster.",
           "required": false,
-          "optional": true,
-          "level": 0
+          "optional": true
         },
         {
           "name": "sourceClusterResourceId",
           "type": "string",
           "description": "(Optional) Cluster resource ID of the source database cluster from which to restore. To be used for restoring a deleted cluster in the same account which still has a retained automatic backup available.",
           "required": false,
-          "optional": true,
-          "level": 0
+          "optional": true
+        },
+        {
+          "name": "useLatestRestorableTime",
+          "type": "bool",
+          "description": "(Optional) Set to true to restore the database cluster to the latest restorable backup time. Defaults to false. Conflicts with `restoreToTime`.",
+          "required": false,
+          "optional": true
         }
       ]
     },
     {
       "name": "s3Import",
+      "full_name": "S3Import",
       "arguments": [
         {
           "name": "bucketName",
           "type": "string",
           "description": "(Required) Bucket name where your backup is stored",
           "required": true,
-          "optional": false,
-          "level": 0
+          "optional": false
         },
         {
           "name": "bucketPrefix",
           "type": "string",
           "description": "(Optional) Can be blank, but is the path to your backup",
           "required": false,
-          "optional": true,
-          "level": 0
+          "optional": true
         },
         {
           "name": "ingestionRole",
           "type": "string",
           "description": "(Required) Role applied to load the data.",
           "required": true,
-          "optional": false,
-          "level": 0
+          "optional": false
         },
         {
           "name": "sourceEngine",
           "type": "string",
           "description": "(Required) Source engine for the backup",
           "required": true,
-          "optional": false,
-          "level": 0
+          "optional": false
         },
         {
           "name": "sourceEngineVersion",
           "type": "string",
           "description": "(Required) Version of the source engine used to make the backup This will not recreate the resource if the S3 object changes in some way. It's only used to initialize the database. This only works currently with the aurora engine. See AWS for currently supported engines and options. See [Aurora S3 Migration Docs](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Migrating.ExtMySQL.html#AuroraMySQL.Migrating.ExtMySQL.S3).",
           "required": true,
-          "optional": false,
-          "level": 0
+          "optional": false
         }
       ]
     },
     {
       "name": "scalingConfiguration",
+      "full_name": "ScalingConfiguration",
       "arguments": [
+        {
+          "name": "autoPause",
+          "type": "bool",
+          "description": "(Optional) Whether to enable automatic pause. A DB cluster can be paused only when it's idle (it has no connections). If a DB cluster is paused for more than seven days, the DB cluster might be backed up with a snapshot. In this case, the DB cluster is restored when there is a request to connect to it. Defaults to `true`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "maxCapacity",
+          "type": "number",
+          "description": "(Optional) Maximum capacity for an Aurora DB cluster in `serverless` DB engine mode. The maximum capacity must be greater than or equal to the minimum capacity. Valid Aurora MySQL capacity values are `1`, `2`, `4`, `8`, `16`, `32`, `64`, `128`, `256`. Valid Aurora PostgreSQL capacity values are (`2`, `4`, `8`, `16`, `32`, `64`, `192`, and `384`). Defaults to `16`.",
+          "required": false,
+          "optional": true
+        },
+        {
+          "name": "minCapacity",
+          "type": "number",
+          "description": "(Optional) Minimum capacity for an Aurora DB cluster in `serverless` DB engine mode. The minimum capacity must be lesser than or equal to the maximum capacity. Valid Aurora MySQL capacity values are `1`, `2`, `4`, `8`, `16`, `32`, `64`, `128`, `256`. Valid Aurora PostgreSQL capacity values are (`2`, `4`, `8`, `16`, `32`, `64`, `192`, and `384`). Defaults to `1`.",
+          "required": false,
+          "optional": true
+        },
         {
           "name": "secondsBeforeTimeout",
           "type": "number",
           "description": "(Optional) Amount of time, in seconds, that Aurora Serverless v1 tries to find a scaling point to perform seamless scaling before enforcing the timeout action. Valid values are `60` through `600`. Defaults to `300`.",
           "required": false,
-          "optional": true,
-          "level": 0
+          "optional": true
         },
         {
           "name": "secondsUntilAutoPause",
           "type": "number",
           "description": "(Optional) Time, in seconds, before an Aurora DB cluster in serverless mode is paused. Valid values are `300` through `86400`. Defaults to `300`.",
           "required": false,
-          "optional": true,
-          "level": 0
+          "optional": true
         },
         {
           "name": "timeoutAction",
           "type": "string",
           "description": "(Optional) Action to take when the timeout is reached. Valid values: `ForceApplyCapacityChange`, `RollbackCapacityChange`. Defaults to `RollbackCapacityChange`. See [documentation](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless-v1.how-it-works.html#aurora-serverless.how-it-works.timeout-action).",
           "required": false,
-          "optional": true,
-          "level": 0
-        },
-        {
-          "name": "autoPause",
-          "type": "bool",
-          "description": "(Optional) Whether to enable automatic pause. A DB cluster can be paused only when it's idle (it has no connections). If a DB cluster is paused for more than seven days, the DB cluster might be backed up with a snapshot. In this case, the DB cluster is restored when there is a request to connect to it. Defaults to `true`.",
-          "required": false,
-          "optional": true,
-          "level": 0
-        },
-        {
-          "name": "maxCapacity",
-          "type": "number",
-          "description": "(Optional) Maximum capacity for an Aurora DB cluster in `serverless` DB engine mode. The maximum capacity must be greater than or equal to the minimum capacity. Valid Aurora MySQL capacity values are `1`, `2`, `4`, `8`, `16`, `32`, `64`, `128`, `256`. Valid Aurora PostgreSQL capacity values are (`2`, `4`, `8`, `16`, `32`, `64`, `192`, and `384`). Defaults to `16`.",
-          "required": false,
-          "optional": true,
-          "level": 0
-        },
-        {
-          "name": "minCapacity",
-          "type": "number",
-          "description": "(Optional) Minimum capacity for an Aurora DB cluster in `serverless` DB engine mode. The minimum capacity must be lesser than or equal to the maximum capacity. Valid Aurora MySQL capacity values are `1`, `2`, `4`, `8`, `16`, `32`, `64`, `128`, `256`. Valid Aurora PostgreSQL capacity values are (`2`, `4`, `8`, `16`, `32`, `64`, `192`, and `384`). Defaults to `1`.",
-          "required": false,
-          "optional": true,
-          "level": 0
+          "optional": true
         }
       ]
     },
     {
       "name": "serverlessv2ScalingConfiguration",
+      "full_name": "Serverlessv2ScalingConfiguration",
       "arguments": [
         {
           "name": "maxCapacity",
           "type": "number",
-          "description": "(Optional) Maximum capacity for an Aurora DB cluster in `serverless` DB engine mode. The maximum capacity must be greater than or equal to the minimum capacity. Valid Aurora MySQL capacity values are `1`, `2`, `4`, `8`, `16`, `32`, `64`, `128`, `256`. Valid Aurora PostgreSQL capacity values are (`2`, `4`, `8`, `16`, `32`, `64`, `192`, and `384`). Defaults to `16`.",
+          "description": "(Required) Maximum capacity for an Aurora DB cluster in `provisioned` DB engine mode. The maximum capacity must be greater than or equal to the minimum capacity. Valid capacity values are in a range of `0` up to `256` in steps of `0.5`.",
           "required": true,
-          "optional": false,
-          "level": 0
+          "optional": false
         },
         {
           "name": "minCapacity",
           "type": "number",
-          "description": "(Optional) Minimum capacity for an Aurora DB cluster in `serverless` DB engine mode. The minimum capacity must be lesser than or equal to the maximum capacity. Valid Aurora MySQL capacity values are `1`, `2`, `4`, `8`, `16`, `32`, `64`, `128`, `256`. Valid Aurora PostgreSQL capacity values are (`2`, `4`, `8`, `16`, `32`, `64`, `192`, and `384`). Defaults to `1`.",
+          "description": "(Required) Minimum capacity for an Aurora DB cluster in `provisioned` DB engine mode. The minimum capacity must be lesser than or equal to the maximum capacity. Valid capacity values are in a range of `0` up to `256` in steps of `0.5`.",
           "required": true,
-          "optional": false,
-          "level": 0
+          "optional": false
         },
         {
           "name": "secondsUntilAutoPause",
           "type": "number",
-          "description": "(Optional) Time, in seconds, before an Aurora DB cluster in serverless mode is paused. Valid values are `300` through `86400`. Defaults to `300`.",
+          "description": "(Optional) Time, in seconds, before an Aurora DB cluster in `provisioned` DB engine mode is paused. Valid values are `300` through `86400`.",
           "required": false,
-          "optional": true,
-          "level": 0
+          "optional": true
         }
       ]
     },
     {
       "name": "timeouts",
+      "full_name": "Timeouts",
       "arguments": [
         {
           "name": "create",
           "type": "string",
           "description": "(Default `120m`) - `update` - (Default `120m`) - `delete` - (Default `120m`) any cleanup task during the destroying process.",
           "required": false,
-          "optional": true,
-          "level": 0
+          "optional": true
         },
         {
           "name": "delete",
           "type": "string",
           "description": "(Default `120m`) any cleanup task during the destroying process.",
           "required": false,
-          "optional": true,
-          "level": 0
+          "optional": true
         },
         {
           "name": "update",
           "type": "string",
           "description": "(Default `120m`) - `delete` - (Default `120m`) any cleanup task during the destroying process.",
           "required": false,
-          "optional": true,
-          "level": 0
+          "optional": true
         }
       ]
     }

--- a/data/reference/docs/typescript/provider-aws/r/rds_cluster_instance.json
+++ b/data/reference/docs/typescript/provider-aws/r/rds_cluster_instance.json
@@ -1,233 +1,290 @@
 {
   "arguments": [
     {
-      "name": "caCertIdentifier",
-      "type": "string",
-      "description": "(Optional) Identifier of the CA certificate for the DB instance.",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "dbParameterGroupName",
-      "type": "string",
-      "description": "(Optional) Name of the DB parameter group to associate with this instance.",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "dbSubnetGroupName",
-      "type": "string",
-      "description": "(Optional, Forces new resource) Specifies the DB subnet group to associate with this DB instance. The default behavior varies depending on whether `dbSubnetGroupName` is specified. Please refer to official [AWS documentation](https://docs.aws.amazon.com/cli/latest/reference/rds/create-db-instance.html) to understand how `dbSubnetGroupName` and `publiclyAccessible` parameters affect DB instance behaviour. **NOTE:** This must match the `dbSubnetGroupName` of the attached [`aws_rds_cluster`](/docs/providers/aws/r/rds_cluster.html).",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "engine",
-      "type": "string",
-      "description": "(Required, Forces new resource) Name of the database engine to be used for the RDS cluster instance.",
-      "required": true,
-      "optional": false,
-      "level": 0
-    },
-    {
-      "name": "preferredBackupWindow",
-      "type": "string",
-      "description": "(Optional) Daily time range during which automated backups are created if automated backups are enabled. Eg: \"04:00-09:00\". **NOTE:** If `preferredBackupWindow` is set at the cluster level, this argument **must** be omitted.",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
       "name": "applyImmediately",
       "type": "bool",
       "description": "(Optional) Specifies whether any database modifications are applied immediately, or during the next maintenance window. Default is`false`.",
       "required": false,
-      "optional": true,
-      "level": 0
+      "optional": true
     },
     {
-      "name": "availabilityZone",
+      "name": "arn",
       "type": "string",
-      "description": "(Optional, Computed, Forces new resource) EC2 Availability Zone that the DB instance is created in. See [docs](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBInstance.html) about the details.",
+      "description": "",
       "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "publiclyAccessible",
-      "type": "bool",
-      "description": "(Optional) Bool to control if instance is publicly accessible. Default `false`. See the documentation on [Creating DB Instances][6] for more details on controlling this property.",
-      "required": false,
-      "optional": true,
-      "level": 0
+      "optional": false
     },
     {
       "name": "autoMinorVersionUpgrade",
       "type": "bool",
       "description": "(Optional) Indicates that minor engine upgrades will be applied automatically to the DB instance during the maintenance window. Default `true`.",
       "required": false,
-      "optional": true,
-      "level": 0
+      "optional": true
     },
     {
-      "name": "forceDestroy",
-      "type": "bool",
-      "description": "(Optional) Forces an instance to be destroyed when a part of a read replica cluster. **Note:** will promote the read replica to a standalone cluster before instance deletion.",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "performanceInsightsKmsKeyId",
+      "name": "availabilityZone",
       "type": "string",
-      "description": "(Optional) ARN for the KMS key to encrypt Performance Insights data. When specifying `performanceInsightsKmsKeyId`, `performanceInsightsEnabled` needs to be set to true.",
+      "description": "(Optional, Computed, Forces new resource) EC2 Availability Zone that the DB instance is created in. See [docs](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBInstance.html) about the details.",
       "required": false,
-      "optional": true,
-      "level": 0
+      "optional": true
     },
     {
-      "name": "preferredMaintenanceWindow",
+      "name": "caCertIdentifier",
       "type": "string",
-      "description": "(Optional) Window to perform maintenance in. Syntax: \"ddd:hh24:mi-ddd:hh24:mi\". Eg: \"Mon:00:00-Mon:03:00\".",
+      "description": "(Optional) Identifier of the CA certificate for the DB instance.",
       "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "engineVersion",
-      "type": "string",
-      "description": "(Optional) Database engine version. Please note that to upgrade the `engineVersion` of the instance, it must be done on the `aws_rds_cluster` `engineVersion`. Trying to upgrade in `aws_cluster_instance` will not update the `engineVersion`.",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "copyTagsToSnapshot",
-      "type": "bool",
-      "description": "(Optional, boolean) Indicates whether to copy all of the user-defined tags from the DB instance to snapshots of the DB instance. Default `false`.",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "customIamInstanceProfile",
-      "type": "string",
-      "description": "(Optional) Instance profile associated with the underlying Amazon EC2 instance of an RDS Custom DB instance.",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "identifierPrefix",
-      "type": "string",
-      "description": "(Optional, Forces new resource) Creates a unique identifier beginning with the specified prefix. Conflicts with `identifier`.",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "monitoringInterval",
-      "type": "number",
-      "description": "(Optional) Interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 0. Valid Values: 0, 1, 5, 10, 15, 30, 60.",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "performanceInsightsEnabled",
-      "type": "bool",
-      "description": "(Optional) Specifies whether Performance Insights is enabled or not. **NOTE:** When Performance Insights is configured at the cluster level through `aws_rds_cluster`, this argument cannot be set to a value that conflicts with the cluster's configuration.",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "performanceInsightsRetentionPeriod",
-      "type": "number",
-      "description": "(Optional) Amount of time in days to retain Performance Insights data. Valid values are `7`, `731` (2 years) or a multiple of `31`. When specifying `performanceInsightsRetentionPeriod`, `performanceInsightsEnabled` needs to be set to true. Defaults to '7'.",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "promotionTier",
-      "type": "number",
-      "description": "(Optional) Default 0. Failover Priority setting on instance level. The reader who has lower tier has higher priority to get promoted to writer.",
-      "required": false,
-      "optional": true,
-      "level": 0
-    },
-    {
-      "name": "identifier",
-      "type": "string",
-      "description": "(Optional, Forces new resource) Identifier for the RDS instance, if omitted, Terraform will assign a random, unique identifier.",
-      "required": false,
-      "optional": true,
-      "level": 0
+      "optional": true
     },
     {
       "name": "clusterIdentifier",
       "type": "string",
       "description": "(Required, Forces new resource) Identifier of the [`aws_rds_cluster`](/docs/providers/aws/r/rds_cluster.html) in which to launch this instance.",
       "required": true,
-      "optional": false,
-      "level": 0
+      "optional": false
+    },
+    {
+      "name": "copyTagsToSnapshot",
+      "type": "bool",
+      "description": "(Optional, boolean) Indicates whether to copy all of the user-defined tags from the DB instance to snapshots of the DB instance. Default `false`.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "customIamInstanceProfile",
+      "type": "string",
+      "description": "(Optional) Instance profile associated with the underlying Amazon EC2 instance of an RDS Custom DB instance.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "dbParameterGroupName",
+      "type": "string",
+      "description": "(Optional) Name of the DB parameter group to associate with this instance.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "dbSubnetGroupName",
+      "type": "string",
+      "description": "(Optional, Forces new resource) Specifies the DB subnet group to associate with this DB instance. The default behavior varies depending on whether `dbSubnetGroupName` is specified. Please refer to official [AWS documentation](https://docs.aws.amazon.com/cli/latest/reference/rds/create-db-instance.html) to understand how `dbSubnetGroupName` and `publiclyAccessible` parameters affect DB instance behaviour. **NOTE:** This must match the `dbSubnetGroupName` of the attached [`aws_rds_cluster`](/docs/providers/aws/r/rds_cluster.html).",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "dbiResourceId",
+      "type": "string",
+      "description": "",
+      "required": false,
+      "optional": false
+    },
+    {
+      "name": "endpoint",
+      "type": "string",
+      "description": "",
+      "required": false,
+      "optional": false
+    },
+    {
+      "name": "engine",
+      "type": "string",
+      "description": "(Required, Forces new resource) Name of the database engine to be used for the RDS cluster instance.",
+      "required": true,
+      "optional": false
+    },
+    {
+      "name": "engineVersion",
+      "type": "string",
+      "description": "(Optional) Database engine version. Please note that to upgrade the `engineVersion` of the instance, it must be done on the `aws_rds_cluster` `engineVersion`. Trying to upgrade in `aws_cluster_instance` will not update the `engineVersion`.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "engineVersionActual",
+      "type": "string",
+      "description": "",
+      "required": false,
+      "optional": false
+    },
+    {
+      "name": "forceDestroy",
+      "type": "bool",
+      "description": "(Optional) Forces an instance to be destroyed when a part of a read replica cluster. **Note:** will promote the read replica to a standalone cluster before instance deletion.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "id",
+      "type": "string",
+      "description": "",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "identifier",
+      "type": "string",
+      "description": "(Optional, Forces new resource) Identifier for the RDS instance, if omitted, Terraform will assign a random, unique identifier.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "identifierPrefix",
+      "type": "string",
+      "description": "(Optional, Forces new resource) Creates a unique identifier beginning with the specified prefix. Conflicts with `identifier`.",
+      "required": false,
+      "optional": true
     },
     {
       "name": "instanceClass",
       "type": "string",
       "description": "(Required) Instance class to use. For details on CPU and memory, see [Scaling Aurora DB Instances][4]. Aurora uses `db.*` instance classes/types. Please see [AWS Documentation][7] for currently available instance classes and complete details. For Aurora Serverless v2 use `db.serverless`.",
       "required": true,
-      "optional": false,
-      "level": 0
+      "optional": false
+    },
+    {
+      "name": "kmsKeyId",
+      "type": "string",
+      "description": "",
+      "required": false,
+      "optional": false
+    },
+    {
+      "name": "monitoringInterval",
+      "type": "number",
+      "description": "(Optional) Interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 0. Valid Values: 0, 1, 5, 10, 15, 30, 60.",
+      "required": false,
+      "optional": true
     },
     {
       "name": "monitoringRoleArn",
       "type": "string",
       "description": "(Optional) ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. You can find more information on the [AWS Documentation](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Monitoring.html) what IAM permissions are needed to allow Enhanced Monitoring for RDS Instances.",
       "required": false,
-      "optional": true,
-      "level": 0
+      "optional": true
+    },
+    {
+      "name": "networkType",
+      "type": "string",
+      "description": "",
+      "required": false,
+      "optional": false
+    },
+    {
+      "name": "performanceInsightsEnabled",
+      "type": "bool",
+      "description": "(Optional) Specifies whether Performance Insights is enabled or not. **NOTE:** When Performance Insights is configured at the cluster level through `aws_rds_cluster`, this argument cannot be set to a value that conflicts with the cluster's configuration.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "performanceInsightsKmsKeyId",
+      "type": "string",
+      "description": "(Optional) ARN for the KMS key to encrypt Performance Insights data. When specifying `performanceInsightsKmsKeyId`, `performanceInsightsEnabled` needs to be set to true.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "performanceInsightsRetentionPeriod",
+      "type": "number",
+      "description": "(Optional) Amount of time in days to retain Performance Insights data. Valid values are `7`, `731` (2 years) or a multiple of `31`. When specifying `performanceInsightsRetentionPeriod`, `performanceInsightsEnabled` needs to be set to true. Defaults to '7'.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "port",
+      "type": "number",
+      "description": "",
+      "required": false,
+      "optional": false
+    },
+    {
+      "name": "preferredBackupWindow",
+      "type": "string",
+      "description": "(Optional) Daily time range during which automated backups are created if automated backups are enabled. Eg: \"04:00-09:00\". **NOTE:** If `preferredBackupWindow` is set at the cluster level, this argument **must** be omitted.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "preferredMaintenanceWindow",
+      "type": "string",
+      "description": "(Optional) Window to perform maintenance in. Syntax: \"ddd:hh24:mi-ddd:hh24:mi\". Eg: \"Mon:00:00-Mon:03:00\".",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "promotionTier",
+      "type": "number",
+      "description": "(Optional) Default 0. Failover Priority setting on instance level. The reader who has lower tier has higher priority to get promoted to writer.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "publiclyAccessible",
+      "type": "bool",
+      "description": "(Optional) Bool to control if instance is publicly accessible. Default `false`. See the documentation on [Creating DB Instances][6] for more details on controlling this property.",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "storageEncrypted",
+      "type": "bool",
+      "description": "",
+      "required": false,
+      "optional": false
     },
     {
       "name": "tags",
       "type": "map",
       "description": "(Optional) Map of tags to assign to the instance. If configured with a provider [`defaultTags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.",
       "required": false,
-      "optional": true,
-      "level": 0
+      "optional": true
+    },
+    {
+      "name": "tagsAll",
+      "type": "map",
+      "description": "",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "timeouts",
+      "type": "block",
+      "description": "",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "writer",
+      "type": "bool",
+      "description": "",
+      "required": false,
+      "optional": false
     }
   ],
   "blocks": [
     {
       "name": "timeouts",
+      "full_name": "Timeouts",
       "arguments": [
         {
           "name": "create",
           "type": "string",
           "description": "(Default `90m`) - `update` - (Default `90m`) - `delete` - (Default `90m`)",
           "required": false,
-          "optional": true,
-          "level": 0
+          "optional": true
         },
         {
           "name": "delete",
           "type": "string",
           "description": "(Default `90m`)",
           "required": false,
-          "optional": true,
-          "level": 0
+          "optional": true
         },
         {
           "name": "update",
           "type": "string",
           "description": "(Default `90m`) - `delete` - (Default `90m`)",
           "required": false,
-          "optional": true,
-          "level": 0
+          "optional": true
         }
       ]
     }

--- a/data/reference/docs/typescript/provider-aws/r/rds_cluster_parameter_group.json
+++ b/data/reference/docs/typescript/provider-aws/r/rds_cluster_parameter_group.json
@@ -1,81 +1,94 @@
 {
   "arguments": [
     {
+      "name": "arn",
+      "type": "string",
+      "description": "",
+      "required": false,
+      "optional": false
+    },
+    {
       "name": "description",
       "type": "string",
       "description": "(Optional) The description of the DB cluster parameter group. Defaults to \"Managed by Terraform\".",
       "required": false,
-      "optional": true,
-      "level": 0
+      "optional": true
     },
     {
       "name": "family",
       "type": "string",
       "description": "(Required) The family of the DB cluster parameter group.",
       "required": true,
-      "optional": false,
-      "level": 0
+      "optional": false
+    },
+    {
+      "name": "id",
+      "type": "string",
+      "description": "",
+      "required": false,
+      "optional": true
     },
     {
       "name": "name",
       "type": "string",
       "description": "(Optional, Forces new resource) The name of the DB cluster parameter group. If omitted, Terraform will assign a random, unique name.",
       "required": false,
-      "optional": true,
-      "level": 0
+      "optional": true
     },
     {
       "name": "namePrefix",
       "type": "string",
       "description": "(Optional, Forces new resource) Creates a unique name beginning with the specified prefix. Conflicts with `name`.",
       "required": false,
-      "optional": true,
-      "level": 0
+      "optional": true
+    },
+    {
+      "name": "parameter",
+      "type": "block",
+      "description": "",
+      "required": false,
+      "optional": true
     },
     {
       "name": "tags",
       "type": "map",
       "description": "(Optional) A map of tags to assign to the resource. If configured with a provider [`defaultTags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.",
       "required": false,
-      "optional": true,
-      "level": 0
+      "optional": true
     },
     {
-      "name": "parameter",
-      "type": "block",
-      "description": "(Optional) A list of DB parameters to apply. Note that parameters may differ from a family to an other. Full list of all parameters can be discovered via [`aws rds describe-db-cluster-parameters`](https://docs.aws.amazon.com/cli/latest/reference/rds/describe-db-cluster-parameters.html) after initial creation of the group.",
+      "name": "tagsAll",
+      "type": "map",
+      "description": "",
       "required": false,
-      "optional": true,
-      "level": 0
+      "optional": true
     }
   ],
   "blocks": [
     {
       "name": "parameter",
+      "full_name": "Parameter",
       "arguments": [
+        {
+          "name": "applyMethod",
+          "type": "string",
+          "description": "(Optional) \"immediate\" (default), or \"pending-reboot\". Some engines can't apply some parameters without a reboot, and you will need to specify \"pending-reboot\" here.",
+          "required": false,
+          "optional": true
+        },
         {
           "name": "name",
           "type": "string",
-          "description": "(Optional, Forces new resource) The name of the DB cluster parameter group. If omitted, Terraform will assign a random, unique name.",
+          "description": "(Required) The name of the DB parameter.",
           "required": true,
-          "optional": false,
-          "level": 0
+          "optional": false
         },
         {
           "name": "value",
           "type": "string",
           "description": "(Required) The value of the DB parameter.",
           "required": true,
-          "optional": false,
-          "level": 0
-        },
-        {
-          "name": "applyMethod",
-          "type": "string",
-          "description": "(Optional) \"immediate\" (default), or \"pending-reboot\". Some engines can't apply some parameters without a reboot, and you will need to specify \"pending-reboot\" here.",
-          "required": false,
-          "optional": true,
-          "level": 0
+          "optional": false
         }
       ]
     }

--- a/data/reference/docs/typescript/provider-aws/r/rds_cluster_role_association.json
+++ b/data/reference/docs/typescript/provider-aws/r/rds_cluster_role_association.json
@@ -1,49 +1,59 @@
 {
   "arguments": [
     {
-      "name": "roleArn",
-      "type": "string",
-      "description": "(Required) Amazon Resource Name (ARN) of the IAM Role to associate with the DB Cluster.",
-      "required": true,
-      "optional": false,
-      "level": 0
-    },
-    {
       "name": "dbClusterIdentifier",
       "type": "string",
       "description": "(Required) DB Cluster Identifier to associate with the IAM Role.",
       "required": true,
-      "optional": false,
-      "level": 0
+      "optional": false
     },
     {
       "name": "featureName",
       "type": "string",
       "description": "(Required) Name of the feature for association. This can be found in the AWS documentation relevant to the integration or a full list is available in the `SupportedFeatureNames` list returned by [AWS CLI rds describe-db-engine-versions](https://docs.aws.amazon.com/cli/latest/reference/rds/describe-db-engine-versions.html).",
       "required": true,
-      "optional": false,
-      "level": 0
+      "optional": false
+    },
+    {
+      "name": "id",
+      "type": "string",
+      "description": "",
+      "required": false,
+      "optional": true
+    },
+    {
+      "name": "roleArn",
+      "type": "string",
+      "description": "(Required) Amazon Resource Name (ARN) of the IAM Role to associate with the DB Cluster.",
+      "required": true,
+      "optional": false
+    },
+    {
+      "name": "timeouts",
+      "type": "block",
+      "description": "",
+      "required": false,
+      "optional": true
     }
   ],
   "blocks": [
     {
       "name": "timeouts",
+      "full_name": "Timeouts",
       "arguments": [
         {
           "name": "create",
           "type": "string",
           "description": "(Default `10m`) - `delete` - (Default `10m`)",
           "required": false,
-          "optional": true,
-          "level": 0
+          "optional": true
         },
         {
           "name": "delete",
           "type": "string",
           "description": "(Default `10m`)",
           "required": false,
-          "optional": true,
-          "level": 0
+          "optional": true
         }
       ]
     }

--- a/data/reference/merged/provider-aws/api-gateway-usage-plan/index.d.ts
+++ b/data/reference/merged/provider-aws/api-gateway-usage-plan/index.d.ts
@@ -29,11 +29,11 @@ export interface ApiGatewayUsagePlanConfig extends cdktf.TerraformMetaArguments 
     readonly throttleSettings?: ApiGatewayUsagePlanThrottleSettings;
 }
 export interface ApiGatewayUsagePlanApiStagesThrottle {
-    /** */
+    /** (Optional) - The API request burst limit, the maximum rate limit over a time ranging from one to a few seconds, depending upon whether the underlying token bucket is at its full capacity. */
     readonly burstLimit?: number;
-    /** */
+    /** (Required) - Method to apply the throttle settings for. Specfiy the path and method, for example `/test/GET`. */
     readonly path: string;
-    /** */
+    /** (Optional) - The API request steady-state rate limit. */
     readonly rateLimit?: number;
 }
 export declare function apiGatewayUsagePlanApiStagesThrottleToTerraform(struct?: ApiGatewayUsagePlanApiStagesThrottle | cdktf.IResolvable): any;
@@ -82,9 +82,9 @@ export declare class ApiGatewayUsagePlanApiStagesThrottleList extends cdktf.Comp
     get(index: number): ApiGatewayUsagePlanApiStagesThrottleOutputReference;
 }
 export interface ApiGatewayUsagePlanApiStages {
-    /** */
+    /** (Required) - API Id of the associated API stage in a usage plan. */
     readonly apiId: string;
-    /** */
+    /** (Required) - API stage name of the associated API stage in a usage plan. */
     readonly stage: string;
     /** */
     readonly throttle?: ApiGatewayUsagePlanApiStagesThrottle[] | cdktf.IResolvable;
@@ -134,11 +134,11 @@ export declare class ApiGatewayUsagePlanApiStagesList extends cdktf.ComplexList 
     get(index: number): ApiGatewayUsagePlanApiStagesOutputReference;
 }
 export interface ApiGatewayUsagePlanQuotaSettings {
-    /** */
+    /** (Optional) - Maximum number of requests that can be made in a given time period. */
     readonly limit: number;
-    /** */
+    /** (Optional) - Number of requests subtracted from the given limit in the initial time period. */
     readonly offset?: number;
-    /** */
+    /** (Optional) - Time period in which the limit applies. Valid values are "DAY", "WEEK" or "MONTH". */
     readonly period: string;
 }
 export declare function apiGatewayUsagePlanQuotaSettingsToTerraform(struct?: ApiGatewayUsagePlanQuotaSettingsOutputReference | ApiGatewayUsagePlanQuotaSettings): any;
@@ -167,9 +167,9 @@ export declare class ApiGatewayUsagePlanQuotaSettingsOutputReference extends cdk
     get periodInput(): string | undefined;
 }
 export interface ApiGatewayUsagePlanThrottleSettings {
-    /** */
+    /** (Optional) - The API request burst limit, the maximum rate limit over a time ranging from one to a few seconds, depending upon whether the underlying token bucket is at its full capacity. */
     readonly burstLimit?: number;
-    /** */
+    /** (Optional) - The API request steady-state rate limit. */
     readonly rateLimit?: number;
 }
 export declare function apiGatewayUsagePlanThrottleSettingsToTerraform(struct?: ApiGatewayUsagePlanThrottleSettingsOutputReference | ApiGatewayUsagePlanThrottleSettings): any;

--- a/data/reference/merged/provider-aws/db-instance-role-association/index.d.ts
+++ b/data/reference/merged/provider-aws/db-instance-role-association/index.d.ts
@@ -9,20 +9,11 @@ export interface DbInstanceRoleAssociationConfig extends cdktf.TerraformMetaArgu
     readonly dbInstanceIdentifier: string;
     /** (Required) Name of the feature for association. This can be found in the AWS documentation relevant to the integration or a full list is available in the `SupportedFeatureNames` list returned by [AWS CLI rds describe-db-engine-versions](https://docs.aws.amazon.com/cli/latest/reference/rds/describe-db-engine-versions.html). */
     readonly featureName: string;
-    /**
-    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.93.0/docs/resources/db_instance_role_association#id DbInstanceRoleAssociation#id}
-    *
-    * Please be aware that the id field is automatically added to all resources in Terraform providers using a Terraform provider SDK version below 2.
-    * If you experience problems setting this value it might not be settable. Please take a look at the provider documentation to ensure it should be settable.
-    */
+    /** */
     readonly id?: string;
     /** (Required) Amazon Resource Name (ARN) of the IAM Role to associate with the DB Instance. */
     readonly roleArn: string;
-    /**
-    * timeouts block
-    *
-    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.93.0/docs/resources/db_instance_role_association#timeouts DbInstanceRoleAssociation#timeouts}
-    */
+    /** */
     readonly timeouts?: DbInstanceRoleAssociationTimeouts;
 }
 export interface DbInstanceRoleAssociationTimeouts {
@@ -55,7 +46,7 @@ export declare class DbInstanceRoleAssociationTimeoutsOutputReference extends cd
     get deleteInput(): string | undefined;
 }
 /**
-* Represents a {@link https://registry.terraform.io/providers/hashicorp/aws/5.93.0/docs/resources/db_instance_role_association aws_db_instance_role_association}
+* Represents a {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/db_instance_role_association aws_db_instance_role_association}
 */
 export declare class DbInstanceRoleAssociation extends cdktf.TerraformResource {
     static readonly tfResourceType = "aws_db_instance_role_association";
@@ -63,12 +54,12 @@ export declare class DbInstanceRoleAssociation extends cdktf.TerraformResource {
     * Generates CDKTF code for importing a DbInstanceRoleAssociation resource upon running "cdktf plan <stack-name>"
     * @param scope The scope in which to define this construct
     * @param importToId The construct id used in the generated config for the DbInstanceRoleAssociation to import
-    * @param importFromId The id of the existing DbInstanceRoleAssociation that should be imported. Refer to the {@link https://registry.terraform.io/providers/hashicorp/aws/5.93.0/docs/resources/db_instance_role_association#import import section} in the documentation of this resource for the id to use
+    * @param importFromId The id of the existing DbInstanceRoleAssociation that should be imported. Refer to the {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/db_instance_role_association#import import section} in the documentation of this resource for the id to use
     * @param provider? Optional instance of the provider where the DbInstanceRoleAssociation to import is found
     */
     static generateConfigForImport(scope: Construct, importToId: string, importFromId: string, provider?: cdktf.TerraformProvider): cdktf.ImportableResource;
     /**
-    * Create a new {@link https://registry.terraform.io/providers/hashicorp/aws/5.93.0/docs/resources/db_instance_role_association aws_db_instance_role_association} Resource
+    * Create a new {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/db_instance_role_association aws_db_instance_role_association} Resource
     *
     * @param scope The scope in which to define this construct
     * @param id The scoped construct ID. Must be unique amongst siblings in the same scope

--- a/data/reference/merged/provider-aws/db-instance/index.d.ts
+++ b/data/reference/merged/provider-aws/db-instance/index.d.ts
@@ -32,7 +32,7 @@ export interface DbInstanceConfig extends cdktf.TerraformMetaArguments {
     /** (Optional) Indicates whether to enable a customer-owned IP address (CoIP) for an RDS on Outposts DB instance. See [CoIP for RDS on Outposts](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-on-outposts.html#rds-on-outposts.coip) for more information. */
     readonly customerOwnedIpEnabled?: boolean | cdktf.IResolvable;
     /**
-    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.93.0/docs/resources/db_instance#database_insights_mode DbInstance#database_insights_mode}
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/db_instance#database_insights_mode DbInstance#database_insights_mode}
     */
     readonly databaseInsightsMode?: string;
     /** (Optional) The name of the database to create when the DB instance is created. If this parameter is not specified, no database is created in the DB instance. Note that this does not apply for Oracle or SQL Server engines. See the [AWS documentation](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/rds/create-db-instance.html) for more details on what applies for those engines. If you are providing an Oracle db name, it needs to be in all upper case. Cannot be specified for a replica. */
@@ -70,7 +70,7 @@ export interface DbInstanceConfig extends cdktf.TerraformMetaArguments {
     /** (Optional) Specifies whether mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled. */
     readonly iamDatabaseAuthenticationEnabled?: boolean | cdktf.IResolvable;
     /**
-    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.93.0/docs/resources/db_instance#id DbInstance#id}
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/db_instance#id DbInstance#id}
     *
     * Please be aware that the id field is automatically added to all resources in Terraform providers using a Terraform provider SDK version below 2.
     * If you experience problems setting this value it might not be settable. Please take a look at the provider documentation to ensure it should be settable.
@@ -113,11 +113,11 @@ export interface DbInstanceConfig extends cdktf.TerraformMetaArguments {
     /** (Required unless `manageMasterUserPassword` is set to true or unless a `snapshotIdentifier` or `replicateSourceDb` is provided or `manageMasterUserPassword` is set.) Password for the master DB user. Note that this may show up in logs, and it will be stored in the state file. Cannot be set if `manageMasterUserPassword` is set to `true`. */
     readonly password?: string;
     /**
-    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.93.0/docs/resources/db_instance#password_wo DbInstance#password_wo}
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/db_instance#password_wo DbInstance#password_wo}
     */
     readonly passwordWo?: string;
     /**
-    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.93.0/docs/resources/db_instance#password_wo_version DbInstance#password_wo_version}
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/db_instance#password_wo_version DbInstance#password_wo_version}
     */
     readonly passwordWoVersion?: number;
     /** (Optional) Specifies whether Performance Insights are enabled. Defaults to false. */
@@ -149,7 +149,7 @@ export interface DbInstanceConfig extends cdktf.TerraformMetaArguments {
         [key: string]: string;
     };
     /**
-    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.93.0/docs/resources/db_instance#tags_all DbInstance#tags_all}
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/db_instance#tags_all DbInstance#tags_all}
     */
     readonly tagsAll?: {
         [key: string]: string;
@@ -171,7 +171,7 @@ export interface DbInstanceConfig extends cdktf.TerraformMetaArguments {
     /**
     * timeouts block
     *
-    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.93.0/docs/resources/db_instance#timeouts DbInstance#timeouts}
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/db_instance#timeouts DbInstance#timeouts}
     */
     readonly timeouts?: DbInstanceTimeouts;
 }
@@ -395,7 +395,7 @@ export declare class DbInstanceTimeoutsOutputReference extends cdktf.ComplexObje
     get updateInput(): string | undefined;
 }
 /**
-* Represents a {@link https://registry.terraform.io/providers/hashicorp/aws/5.93.0/docs/resources/db_instance aws_db_instance}
+* Represents a {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/db_instance aws_db_instance}
 */
 export declare class DbInstance extends cdktf.TerraformResource {
     static readonly tfResourceType = "aws_db_instance";
@@ -403,12 +403,12 @@ export declare class DbInstance extends cdktf.TerraformResource {
     * Generates CDKTF code for importing a DbInstance resource upon running "cdktf plan <stack-name>"
     * @param scope The scope in which to define this construct
     * @param importToId The construct id used in the generated config for the DbInstance to import
-    * @param importFromId The id of the existing DbInstance that should be imported. Refer to the {@link https://registry.terraform.io/providers/hashicorp/aws/5.93.0/docs/resources/db_instance#import import section} in the documentation of this resource for the id to use
+    * @param importFromId The id of the existing DbInstance that should be imported. Refer to the {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/db_instance#import import section} in the documentation of this resource for the id to use
     * @param provider? Optional instance of the provider where the DbInstance to import is found
     */
     static generateConfigForImport(scope: Construct, importToId: string, importFromId: string, provider?: cdktf.TerraformProvider): cdktf.ImportableResource;
     /**
-    * Create a new {@link https://registry.terraform.io/providers/hashicorp/aws/5.93.0/docs/resources/db_instance aws_db_instance} Resource
+    * Create a new {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/db_instance aws_db_instance} Resource
     *
     * @param scope The scope in which to define this construct
     * @param id The scoped construct ID. Must be unique amongst siblings in the same scope

--- a/data/reference/merged/provider-aws/db-option-group/index.d.ts
+++ b/data/reference/merged/provider-aws/db-option-group/index.d.ts
@@ -7,12 +7,7 @@ import * as cdktf from 'cdktf';
 export interface DbOptionGroupConfig extends cdktf.TerraformMetaArguments {
     /** (Required) Specifies the name of the engine that this option group should be associated with. */
     readonly engineName: string;
-    /**
-    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.93.0/docs/resources/db_option_group#id DbOptionGroup#id}
-    *
-    * Please be aware that the id field is automatically added to all resources in Terraform providers using a Terraform provider SDK version below 2.
-    * If you experience problems setting this value it might not be settable. Please take a look at the provider documentation to ensure it should be settable.
-    */
+    /** */
     readonly id?: string;
     /** (Required) Specifies the major version of the engine that this option group should be associated with. */
     readonly majorEngineVersion: string;
@@ -28,29 +23,19 @@ export interface DbOptionGroupConfig extends cdktf.TerraformMetaArguments {
     readonly tags?: {
         [key: string]: string;
     };
-    /**
-    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.93.0/docs/resources/db_option_group#tags_all DbOptionGroup#tags_all}
-    */
+    /** */
     readonly tagsAll?: {
         [key: string]: string;
     };
-    /** (Optional) The options to apply. See [`option` Block](#option-block) below for more details. */
+    /** */
     readonly option?: DbOptionGroupOption[] | cdktf.IResolvable;
-    /**
-    * timeouts block
-    *
-    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.93.0/docs/resources/db_option_group#timeouts DbOptionGroup#timeouts}
-    */
+    /** */
     readonly timeouts?: DbOptionGroupTimeouts;
 }
 export interface DbOptionGroupOptionOptionSettings {
-    /**
-    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.93.0/docs/resources/db_option_group#name DbOptionGroup#name}
-    */
+    /** (Required) Name of the setting. */
     readonly name: string;
-    /**
-    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.93.0/docs/resources/db_option_group#value DbOptionGroup#value}
-    */
+    /** (Required) Value of the setting. */
     readonly value: string;
 }
 export declare function dbOptionGroupOptionOptionSettingsToTerraform(struct?: DbOptionGroupOptionOptionSettings | cdktf.IResolvable): any;
@@ -103,7 +88,7 @@ export interface DbOptionGroupOption {
     readonly version?: string;
     /** (Optional) List of VPC Security Groups for which the option is enabled. */
     readonly vpcSecurityGroupMemberships?: string[];
-    /** (Optional) The option settings to apply. See [`optionSettings` Block](#option_settings-block) below for more details. */
+    /** */
     readonly optionSettings?: DbOptionGroupOptionOptionSettings[] | cdktf.IResolvable;
 }
 export declare function dbOptionGroupOptionToTerraform(struct?: DbOptionGroupOption | cdktf.IResolvable): any;
@@ -189,7 +174,7 @@ export declare class DbOptionGroupTimeoutsOutputReference extends cdktf.ComplexO
     get deleteInput(): string | undefined;
 }
 /**
-* Represents a {@link https://registry.terraform.io/providers/hashicorp/aws/5.93.0/docs/resources/db_option_group aws_db_option_group}
+* Represents a {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/db_option_group aws_db_option_group}
 */
 export declare class DbOptionGroup extends cdktf.TerraformResource {
     static readonly tfResourceType = "aws_db_option_group";
@@ -197,12 +182,12 @@ export declare class DbOptionGroup extends cdktf.TerraformResource {
     * Generates CDKTF code for importing a DbOptionGroup resource upon running "cdktf plan <stack-name>"
     * @param scope The scope in which to define this construct
     * @param importToId The construct id used in the generated config for the DbOptionGroup to import
-    * @param importFromId The id of the existing DbOptionGroup that should be imported. Refer to the {@link https://registry.terraform.io/providers/hashicorp/aws/5.93.0/docs/resources/db_option_group#import import section} in the documentation of this resource for the id to use
+    * @param importFromId The id of the existing DbOptionGroup that should be imported. Refer to the {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/db_option_group#import import section} in the documentation of this resource for the id to use
     * @param provider? Optional instance of the provider where the DbOptionGroup to import is found
     */
     static generateConfigForImport(scope: Construct, importToId: string, importFromId: string, provider?: cdktf.TerraformProvider): cdktf.ImportableResource;
     /**
-    * Create a new {@link https://registry.terraform.io/providers/hashicorp/aws/5.93.0/docs/resources/db_option_group aws_db_option_group} Resource
+    * Create a new {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/db_option_group aws_db_option_group} Resource
     *
     * @param scope The scope in which to define this construct
     * @param id The scoped construct ID. Must be unique amongst siblings in the same scope

--- a/data/reference/merged/provider-aws/ecr-repository-creation-template/index.d.ts
+++ b/data/reference/merged/provider-aws/ecr-repository-creation-template/index.d.ts
@@ -1,0 +1,160 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+import { Construct } from 'constructs';
+import * as cdktf from 'cdktf';
+export interface EcrRepositoryCreationTemplateConfig extends cdktf.TerraformMetaArguments {
+    /** (Required) Which features this template applies to. Must contain one or more of `PULL_THROUGH_CACHE` or `REPLICATION`. */
+    readonly appliedFor: string[];
+    /** (Optional) A custom IAM role to use for repository creation. Required if using repository tags or KMS encryption. */
+    readonly customRoleArn?: string;
+    /** (Optional) The description for this template. */
+    readonly description?: string;
+    /** */
+    readonly id?: string;
+    /** (Optional) The tag mutability setting for any created repositories. Must be one of: `MUTABLE` or `IMMUTABLE`. Defaults to `MUTABLE`. */
+    readonly imageTagMutability?: string;
+    /** (Optional) The lifecycle policy document to apply to any created repositories. See more details about [Policy Parameters](http://docs.aws.amazon.com/AmazonECR/latest/userguide/LifecyclePolicies.html#lifecycle_policy_parameters) in the official AWS docs. Consider using the [`aws_ecr_lifecycle_policy_document` data_source](/docs/providers/aws/d/ecr_lifecycle_policy_document.html) to generate/manage the JSON document used for the `lifecyclePolicy` argument. */
+    readonly lifecyclePolicy?: string;
+    /** (Required, Forces new resource) The repository name prefix to match against. Use `ROOT` to match any prefix that doesn't explicitly match another template. */
+    readonly prefix: string;
+    /** (Optional) The registry policy document to apply to any created repositories. This is a JSON formatted string. For more information about building IAM policy documents with Terraform, see the [AWS IAM Policy Document Guide](https://learn.hashicorp.com/terraform/aws/iam-policy). */
+    readonly repositoryPolicy?: string;
+    /** (Optional) A map of tags to assign to any created repositories. */
+    readonly resourceTags?: {
+        [key: string]: string;
+    };
+    /** */
+    readonly encryptionConfiguration?: EcrRepositoryCreationTemplateEncryptionConfiguration[] | cdktf.IResolvable;
+}
+export interface EcrRepositoryCreationTemplateEncryptionConfiguration {
+    /** (Optional) The encryption type to use for any created repositories. Valid values are `AES256` or `KMS`. Defaults to `AES256`. */
+    readonly encryptionType?: string;
+    /** (Optional) The ARN of the KMS key to use when `encryptionType` is `KMS`. If not specified, uses the default AWS managed key for ECR. */
+    readonly kmsKey?: string;
+}
+export declare function ecrRepositoryCreationTemplateEncryptionConfigurationToTerraform(struct?: EcrRepositoryCreationTemplateEncryptionConfiguration | cdktf.IResolvable): any;
+export declare function ecrRepositoryCreationTemplateEncryptionConfigurationToHclTerraform(struct?: EcrRepositoryCreationTemplateEncryptionConfiguration | cdktf.IResolvable): any;
+export declare class EcrRepositoryCreationTemplateEncryptionConfigurationOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    private resolvableValue?;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    * @param complexObjectIndex the index of this item in the list
+    * @param complexObjectIsFromSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string, complexObjectIndex: number, complexObjectIsFromSet: boolean);
+    get internalValue(): EcrRepositoryCreationTemplateEncryptionConfiguration | cdktf.IResolvable | undefined;
+    set internalValue(value: EcrRepositoryCreationTemplateEncryptionConfiguration | cdktf.IResolvable | undefined);
+    private _encryptionType?;
+    get encryptionType(): string;
+    set encryptionType(value: string);
+    resetEncryptionType(): void;
+    get encryptionTypeInput(): string | undefined;
+    private _kmsKey?;
+    get kmsKey(): string;
+    set kmsKey(value: string);
+    resetKmsKey(): void;
+    get kmsKeyInput(): string | undefined;
+}
+export declare class EcrRepositoryCreationTemplateEncryptionConfigurationList extends cdktf.ComplexList {
+    protected terraformResource: cdktf.IInterpolatingParent;
+    protected terraformAttribute: string;
+    protected wrapsSet: boolean;
+    internalValue?: EcrRepositoryCreationTemplateEncryptionConfiguration[] | cdktf.IResolvable;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    * @param wrapsSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string, wrapsSet: boolean);
+    /**
+    * @param index the index of the item to return
+    */
+    get(index: number): EcrRepositoryCreationTemplateEncryptionConfigurationOutputReference;
+}
+/**
+* Represents a {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/ecr_repository_creation_template aws_ecr_repository_creation_template}
+*/
+export declare class EcrRepositoryCreationTemplate extends cdktf.TerraformResource {
+    static readonly tfResourceType = "aws_ecr_repository_creation_template";
+    /**
+    * Generates CDKTF code for importing a EcrRepositoryCreationTemplate resource upon running "cdktf plan <stack-name>"
+    * @param scope The scope in which to define this construct
+    * @param importToId The construct id used in the generated config for the EcrRepositoryCreationTemplate to import
+    * @param importFromId The id of the existing EcrRepositoryCreationTemplate that should be imported. Refer to the {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/ecr_repository_creation_template#import import section} in the documentation of this resource for the id to use
+    * @param provider? Optional instance of the provider where the EcrRepositoryCreationTemplate to import is found
+    */
+    static generateConfigForImport(scope: Construct, importToId: string, importFromId: string, provider?: cdktf.TerraformProvider): cdktf.ImportableResource;
+    /**
+    * Create a new {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/ecr_repository_creation_template aws_ecr_repository_creation_template} Resource
+    *
+    * @param scope The scope in which to define this construct
+    * @param id The scoped construct ID. Must be unique amongst siblings in the same scope
+    * @param options EcrRepositoryCreationTemplateConfig
+    */
+    constructor(scope: Construct, id: string, config: EcrRepositoryCreationTemplateConfig);
+    private _appliedFor?;
+    get appliedFor(): string[];
+    set appliedFor(value: string[]);
+    get appliedForInput(): string[] | undefined;
+    private _customRoleArn?;
+    get customRoleArn(): string;
+    set customRoleArn(value: string);
+    resetCustomRoleArn(): void;
+    get customRoleArnInput(): string | undefined;
+    private _description?;
+    get description(): string;
+    set description(value: string);
+    resetDescription(): void;
+    get descriptionInput(): string | undefined;
+    private _id?;
+    get id(): string;
+    set id(value: string);
+    resetId(): void;
+    get idInput(): string | undefined;
+    private _imageTagMutability?;
+    get imageTagMutability(): string;
+    set imageTagMutability(value: string);
+    resetImageTagMutability(): void;
+    get imageTagMutabilityInput(): string | undefined;
+    private _lifecyclePolicy?;
+    get lifecyclePolicy(): string;
+    set lifecyclePolicy(value: string);
+    resetLifecyclePolicy(): void;
+    get lifecyclePolicyInput(): string | undefined;
+    private _prefix?;
+    get prefix(): string;
+    set prefix(value: string);
+    get prefixInput(): string | undefined;
+    get registryId(): string;
+    private _repositoryPolicy?;
+    get repositoryPolicy(): string;
+    set repositoryPolicy(value: string);
+    resetRepositoryPolicy(): void;
+    get repositoryPolicyInput(): string | undefined;
+    private _resourceTags?;
+    get resourceTags(): {
+        [key: string]: string;
+    };
+    set resourceTags(value: {
+        [key: string]: string;
+    });
+    resetResourceTags(): void;
+    get resourceTagsInput(): {
+        [key: string]: string;
+    } | undefined;
+    private _encryptionConfiguration;
+    get encryptionConfiguration(): EcrRepositoryCreationTemplateEncryptionConfigurationList;
+    putEncryptionConfiguration(value: EcrRepositoryCreationTemplateEncryptionConfiguration[] | cdktf.IResolvable): void;
+    resetEncryptionConfiguration(): void;
+    get encryptionConfigurationInput(): cdktf.IResolvable | EcrRepositoryCreationTemplateEncryptionConfiguration[] | undefined;
+    protected synthesizeAttributes(): {
+        [name: string]: any;
+    };
+    protected synthesizeHclAttributes(): {
+        [name: string]: any;
+    };
+}

--- a/data/reference/merged/provider-aws/ecr-repository/index.d.ts
+++ b/data/reference/merged/provider-aws/ecr-repository/index.d.ts
@@ -1,0 +1,206 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+import { Construct } from 'constructs';
+import * as cdktf from 'cdktf';
+export interface EcrRepositoryConfig extends cdktf.TerraformMetaArguments {
+    /** (Optional) If `true`, will delete the repository even if it contains images. */
+    readonly forceDelete?: boolean | cdktf.IResolvable;
+    /** */
+    readonly id?: string;
+    /** (Optional) The tag mutability setting for the repository. Must be one of: `MUTABLE` or `IMMUTABLE`. Defaults to `MUTABLE`. */
+    readonly imageTagMutability?: string;
+    /** (Required) Name of the repository. */
+    readonly name: string;
+    /** (Optional) A map of tags to assign to the resource. If configured with a provider [`defaultTags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level. */
+    readonly tags?: {
+        [key: string]: string;
+    };
+    /** */
+    readonly tagsAll?: {
+        [key: string]: string;
+    };
+    /** */
+    readonly encryptionConfiguration?: EcrRepositoryEncryptionConfiguration[] | cdktf.IResolvable;
+    /** */
+    readonly imageScanningConfiguration?: EcrRepositoryImageScanningConfiguration;
+    /** */
+    readonly timeouts?: EcrRepositoryTimeouts;
+}
+export interface EcrRepositoryEncryptionConfiguration {
+    /** (Optional) The encryption type to use for the repository. Valid values are `AES256` or `KMS`. Defaults to `AES256`. */
+    readonly encryptionType?: string;
+    /** (Optional) The ARN of the KMS key to use when `encryptionType` is `KMS`. If not specified, uses the default AWS managed key for ECR. */
+    readonly kmsKey?: string;
+}
+export declare function ecrRepositoryEncryptionConfigurationToTerraform(struct?: EcrRepositoryEncryptionConfiguration | cdktf.IResolvable): any;
+export declare function ecrRepositoryEncryptionConfigurationToHclTerraform(struct?: EcrRepositoryEncryptionConfiguration | cdktf.IResolvable): any;
+export declare class EcrRepositoryEncryptionConfigurationOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    private resolvableValue?;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    * @param complexObjectIndex the index of this item in the list
+    * @param complexObjectIsFromSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string, complexObjectIndex: number, complexObjectIsFromSet: boolean);
+    get internalValue(): EcrRepositoryEncryptionConfiguration | cdktf.IResolvable | undefined;
+    set internalValue(value: EcrRepositoryEncryptionConfiguration | cdktf.IResolvable | undefined);
+    private _encryptionType?;
+    get encryptionType(): string;
+    set encryptionType(value: string);
+    resetEncryptionType(): void;
+    get encryptionTypeInput(): string | undefined;
+    private _kmsKey?;
+    get kmsKey(): string;
+    set kmsKey(value: string);
+    resetKmsKey(): void;
+    get kmsKeyInput(): string | undefined;
+}
+export declare class EcrRepositoryEncryptionConfigurationList extends cdktf.ComplexList {
+    protected terraformResource: cdktf.IInterpolatingParent;
+    protected terraformAttribute: string;
+    protected wrapsSet: boolean;
+    internalValue?: EcrRepositoryEncryptionConfiguration[] | cdktf.IResolvable;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    * @param wrapsSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string, wrapsSet: boolean);
+    /**
+    * @param index the index of the item to return
+    */
+    get(index: number): EcrRepositoryEncryptionConfigurationOutputReference;
+}
+export interface EcrRepositoryImageScanningConfiguration {
+    /** (Required) Indicates whether images are scanned after being pushed to the repository (true) or not scanned (false). */
+    readonly scanOnPush: boolean | cdktf.IResolvable;
+}
+export declare function ecrRepositoryImageScanningConfigurationToTerraform(struct?: EcrRepositoryImageScanningConfigurationOutputReference | EcrRepositoryImageScanningConfiguration): any;
+export declare function ecrRepositoryImageScanningConfigurationToHclTerraform(struct?: EcrRepositoryImageScanningConfigurationOutputReference | EcrRepositoryImageScanningConfiguration): any;
+export declare class EcrRepositoryImageScanningConfigurationOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): EcrRepositoryImageScanningConfiguration | undefined;
+    set internalValue(value: EcrRepositoryImageScanningConfiguration | undefined);
+    private _scanOnPush?;
+    get scanOnPush(): boolean | cdktf.IResolvable;
+    set scanOnPush(value: boolean | cdktf.IResolvable);
+    get scanOnPushInput(): boolean | cdktf.IResolvable | undefined;
+}
+export interface EcrRepositoryTimeouts {
+    /** (Default `20m`) */
+    readonly delete?: string;
+}
+export declare function ecrRepositoryTimeoutsToTerraform(struct?: EcrRepositoryTimeouts | cdktf.IResolvable): any;
+export declare function ecrRepositoryTimeoutsToHclTerraform(struct?: EcrRepositoryTimeouts | cdktf.IResolvable): any;
+export declare class EcrRepositoryTimeoutsOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    private resolvableValue?;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): EcrRepositoryTimeouts | cdktf.IResolvable | undefined;
+    set internalValue(value: EcrRepositoryTimeouts | cdktf.IResolvable | undefined);
+    private _delete?;
+    get delete(): string;
+    set delete(value: string);
+    resetDelete(): void;
+    get deleteInput(): string | undefined;
+}
+/**
+* Represents a {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/ecr_repository aws_ecr_repository}
+*/
+export declare class EcrRepository extends cdktf.TerraformResource {
+    static readonly tfResourceType = "aws_ecr_repository";
+    /**
+    * Generates CDKTF code for importing a EcrRepository resource upon running "cdktf plan <stack-name>"
+    * @param scope The scope in which to define this construct
+    * @param importToId The construct id used in the generated config for the EcrRepository to import
+    * @param importFromId The id of the existing EcrRepository that should be imported. Refer to the {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/ecr_repository#import import section} in the documentation of this resource for the id to use
+    * @param provider? Optional instance of the provider where the EcrRepository to import is found
+    */
+    static generateConfigForImport(scope: Construct, importToId: string, importFromId: string, provider?: cdktf.TerraformProvider): cdktf.ImportableResource;
+    /**
+    * Create a new {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/ecr_repository aws_ecr_repository} Resource
+    *
+    * @param scope The scope in which to define this construct
+    * @param id The scoped construct ID. Must be unique amongst siblings in the same scope
+    * @param options EcrRepositoryConfig
+    */
+    constructor(scope: Construct, id: string, config: EcrRepositoryConfig);
+    get arn(): string;
+    private _forceDelete?;
+    get forceDelete(): boolean | cdktf.IResolvable;
+    set forceDelete(value: boolean | cdktf.IResolvable);
+    resetForceDelete(): void;
+    get forceDeleteInput(): boolean | cdktf.IResolvable | undefined;
+    private _id?;
+    get id(): string;
+    set id(value: string);
+    resetId(): void;
+    get idInput(): string | undefined;
+    private _imageTagMutability?;
+    get imageTagMutability(): string;
+    set imageTagMutability(value: string);
+    resetImageTagMutability(): void;
+    get imageTagMutabilityInput(): string | undefined;
+    private _name?;
+    get name(): string;
+    set name(value: string);
+    get nameInput(): string | undefined;
+    get registryId(): string;
+    get repositoryUrl(): string;
+    private _tags?;
+    get tags(): {
+        [key: string]: string;
+    };
+    set tags(value: {
+        [key: string]: string;
+    });
+    resetTags(): void;
+    get tagsInput(): {
+        [key: string]: string;
+    } | undefined;
+    private _tagsAll?;
+    get tagsAll(): {
+        [key: string]: string;
+    };
+    set tagsAll(value: {
+        [key: string]: string;
+    });
+    resetTagsAll(): void;
+    get tagsAllInput(): {
+        [key: string]: string;
+    } | undefined;
+    private _encryptionConfiguration;
+    get encryptionConfiguration(): EcrRepositoryEncryptionConfigurationList;
+    putEncryptionConfiguration(value: EcrRepositoryEncryptionConfiguration[] | cdktf.IResolvable): void;
+    resetEncryptionConfiguration(): void;
+    get encryptionConfigurationInput(): cdktf.IResolvable | EcrRepositoryEncryptionConfiguration[] | undefined;
+    private _imageScanningConfiguration;
+    get imageScanningConfiguration(): EcrRepositoryImageScanningConfigurationOutputReference;
+    putImageScanningConfiguration(value: EcrRepositoryImageScanningConfiguration): void;
+    resetImageScanningConfiguration(): void;
+    get imageScanningConfigurationInput(): EcrRepositoryImageScanningConfiguration | undefined;
+    private _timeouts;
+    get timeouts(): EcrRepositoryTimeoutsOutputReference;
+    putTimeouts(value: EcrRepositoryTimeouts): void;
+    resetTimeouts(): void;
+    get timeoutsInput(): cdktf.IResolvable | EcrRepositoryTimeouts | undefined;
+    protected synthesizeAttributes(): {
+        [name: string]: any;
+    };
+    protected synthesizeHclAttributes(): {
+        [name: string]: any;
+    };
+}

--- a/data/reference/merged/provider-aws/ecrpublic-repository-policy/index.d.ts
+++ b/data/reference/merged/provider-aws/ecrpublic-repository-policy/index.d.ts
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+import { Construct } from 'constructs';
+import * as cdktf from 'cdktf';
+export interface EcrpublicRepositoryPolicyConfig extends cdktf.TerraformMetaArguments {
+    /** */
+    readonly id?: string;
+    /** (Required) The policy document. This is a JSON formatted string. For more information about building IAM policy documents with Terraform, see the [AWS IAM Policy Document Guide](https://learn.hashicorp.com/terraform/aws/iam-policy) */
+    readonly policy: string;
+    /** (Required) Name of the repository to apply the policy. */
+    readonly repositoryName: string;
+}
+/**
+* Represents a {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/ecrpublic_repository_policy aws_ecrpublic_repository_policy}
+*/
+export declare class EcrpublicRepositoryPolicy extends cdktf.TerraformResource {
+    static readonly tfResourceType = "aws_ecrpublic_repository_policy";
+    /**
+    * Generates CDKTF code for importing a EcrpublicRepositoryPolicy resource upon running "cdktf plan <stack-name>"
+    * @param scope The scope in which to define this construct
+    * @param importToId The construct id used in the generated config for the EcrpublicRepositoryPolicy to import
+    * @param importFromId The id of the existing EcrpublicRepositoryPolicy that should be imported. Refer to the {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/ecrpublic_repository_policy#import import section} in the documentation of this resource for the id to use
+    * @param provider? Optional instance of the provider where the EcrpublicRepositoryPolicy to import is found
+    */
+    static generateConfigForImport(scope: Construct, importToId: string, importFromId: string, provider?: cdktf.TerraformProvider): cdktf.ImportableResource;
+    /**
+    * Create a new {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/ecrpublic_repository_policy aws_ecrpublic_repository_policy} Resource
+    *
+    * @param scope The scope in which to define this construct
+    * @param id The scoped construct ID. Must be unique amongst siblings in the same scope
+    * @param options EcrpublicRepositoryPolicyConfig
+    */
+    constructor(scope: Construct, id: string, config: EcrpublicRepositoryPolicyConfig);
+    private _id?;
+    get id(): string;
+    set id(value: string);
+    resetId(): void;
+    get idInput(): string | undefined;
+    private _policy?;
+    get policy(): string;
+    set policy(value: string);
+    get policyInput(): string | undefined;
+    get registryId(): string;
+    private _repositoryName?;
+    get repositoryName(): string;
+    set repositoryName(value: string);
+    get repositoryNameInput(): string | undefined;
+    protected synthesizeAttributes(): {
+        [name: string]: any;
+    };
+    protected synthesizeHclAttributes(): {
+        [name: string]: any;
+    };
+}

--- a/data/reference/merged/provider-aws/ecrpublic-repository/index.d.ts
+++ b/data/reference/merged/provider-aws/ecrpublic-repository/index.d.ts
@@ -1,0 +1,181 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+import { Construct } from 'constructs';
+import * as cdktf from 'cdktf';
+export interface EcrpublicRepositoryConfig extends cdktf.TerraformMetaArguments {
+    /** */
+    readonly forceDestroy?: boolean | cdktf.IResolvable;
+    /** */
+    readonly id?: string;
+    /** (Required) Name of the repository. */
+    readonly repositoryName: string;
+    /** (Optional) Key-value mapping of resource tags. If configured with a provider [`defaultTags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level. */
+    readonly tags?: {
+        [key: string]: string;
+    };
+    /** */
+    readonly tagsAll?: {
+        [key: string]: string;
+    };
+    /** */
+    readonly catalogData?: EcrpublicRepositoryCatalogData;
+    /** */
+    readonly timeouts?: EcrpublicRepositoryTimeouts;
+}
+export interface EcrpublicRepositoryCatalogData {
+    /** (Optional) A detailed description of the contents of the repository. It is publicly visible in the Amazon ECR Public Gallery. The text must be in markdown format. */
+    readonly aboutText?: string;
+    /** (Optional) The system architecture that the images in the repository are compatible with. On the Amazon ECR Public Gallery, the following supported architectures will appear as badges on the repository and are used as search filters: `ARM`, `ARM 64`, `x86`, `x86-64` */
+    readonly architectures?: string[];
+    /** (Optional) A short description of the contents of the repository. This text appears in both the image details and also when searching for repositories on the Amazon ECR Public Gallery. */
+    readonly description?: string;
+    /** (Optional) The base64-encoded repository logo payload. (Only visible for verified accounts) Note that drift detection is disabled for this attribute. */
+    readonly logoImageBlob?: string;
+    /** (Optional) The operating systems that the images in the repository are compatible with. On the Amazon ECR Public Gallery, the following supported operating systems will appear as badges on the repository and are used as search filters: `Linux`, `Windows` */
+    readonly operatingSystems?: string[];
+    /** (Optional) Detailed information on how to use the contents of the repository. It is publicly visible in the Amazon ECR Public Gallery. The usage text provides context, support information, and additional usage details for users of the repository. The text must be in markdown format. */
+    readonly usageText?: string;
+}
+export declare function ecrpublicRepositoryCatalogDataToTerraform(struct?: EcrpublicRepositoryCatalogDataOutputReference | EcrpublicRepositoryCatalogData): any;
+export declare function ecrpublicRepositoryCatalogDataToHclTerraform(struct?: EcrpublicRepositoryCatalogDataOutputReference | EcrpublicRepositoryCatalogData): any;
+export declare class EcrpublicRepositoryCatalogDataOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): EcrpublicRepositoryCatalogData | undefined;
+    set internalValue(value: EcrpublicRepositoryCatalogData | undefined);
+    private _aboutText?;
+    get aboutText(): string;
+    set aboutText(value: string);
+    resetAboutText(): void;
+    get aboutTextInput(): string | undefined;
+    private _architectures?;
+    get architectures(): string[];
+    set architectures(value: string[]);
+    resetArchitectures(): void;
+    get architecturesInput(): string[] | undefined;
+    private _description?;
+    get description(): string;
+    set description(value: string);
+    resetDescription(): void;
+    get descriptionInput(): string | undefined;
+    private _logoImageBlob?;
+    get logoImageBlob(): string;
+    set logoImageBlob(value: string);
+    resetLogoImageBlob(): void;
+    get logoImageBlobInput(): string | undefined;
+    private _operatingSystems?;
+    get operatingSystems(): string[];
+    set operatingSystems(value: string[]);
+    resetOperatingSystems(): void;
+    get operatingSystemsInput(): string[] | undefined;
+    private _usageText?;
+    get usageText(): string;
+    set usageText(value: string);
+    resetUsageText(): void;
+    get usageTextInput(): string | undefined;
+}
+export interface EcrpublicRepositoryTimeouts {
+    /** (Default `20m`) */
+    readonly delete?: string;
+}
+export declare function ecrpublicRepositoryTimeoutsToTerraform(struct?: EcrpublicRepositoryTimeouts | cdktf.IResolvable): any;
+export declare function ecrpublicRepositoryTimeoutsToHclTerraform(struct?: EcrpublicRepositoryTimeouts | cdktf.IResolvable): any;
+export declare class EcrpublicRepositoryTimeoutsOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    private resolvableValue?;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): EcrpublicRepositoryTimeouts | cdktf.IResolvable | undefined;
+    set internalValue(value: EcrpublicRepositoryTimeouts | cdktf.IResolvable | undefined);
+    private _delete?;
+    get delete(): string;
+    set delete(value: string);
+    resetDelete(): void;
+    get deleteInput(): string | undefined;
+}
+/**
+* Represents a {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/ecrpublic_repository aws_ecrpublic_repository}
+*/
+export declare class EcrpublicRepository extends cdktf.TerraformResource {
+    static readonly tfResourceType = "aws_ecrpublic_repository";
+    /**
+    * Generates CDKTF code for importing a EcrpublicRepository resource upon running "cdktf plan <stack-name>"
+    * @param scope The scope in which to define this construct
+    * @param importToId The construct id used in the generated config for the EcrpublicRepository to import
+    * @param importFromId The id of the existing EcrpublicRepository that should be imported. Refer to the {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/ecrpublic_repository#import import section} in the documentation of this resource for the id to use
+    * @param provider? Optional instance of the provider where the EcrpublicRepository to import is found
+    */
+    static generateConfigForImport(scope: Construct, importToId: string, importFromId: string, provider?: cdktf.TerraformProvider): cdktf.ImportableResource;
+    /**
+    * Create a new {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/ecrpublic_repository aws_ecrpublic_repository} Resource
+    *
+    * @param scope The scope in which to define this construct
+    * @param id The scoped construct ID. Must be unique amongst siblings in the same scope
+    * @param options EcrpublicRepositoryConfig
+    */
+    constructor(scope: Construct, id: string, config: EcrpublicRepositoryConfig);
+    get arn(): string;
+    private _forceDestroy?;
+    get forceDestroy(): boolean | cdktf.IResolvable;
+    set forceDestroy(value: boolean | cdktf.IResolvable);
+    resetForceDestroy(): void;
+    get forceDestroyInput(): boolean | cdktf.IResolvable | undefined;
+    private _id?;
+    get id(): string;
+    set id(value: string);
+    resetId(): void;
+    get idInput(): string | undefined;
+    get registryId(): string;
+    private _repositoryName?;
+    get repositoryName(): string;
+    set repositoryName(value: string);
+    get repositoryNameInput(): string | undefined;
+    get repositoryUri(): string;
+    private _tags?;
+    get tags(): {
+        [key: string]: string;
+    };
+    set tags(value: {
+        [key: string]: string;
+    });
+    resetTags(): void;
+    get tagsInput(): {
+        [key: string]: string;
+    } | undefined;
+    private _tagsAll?;
+    get tagsAll(): {
+        [key: string]: string;
+    };
+    set tagsAll(value: {
+        [key: string]: string;
+    });
+    resetTagsAll(): void;
+    get tagsAllInput(): {
+        [key: string]: string;
+    } | undefined;
+    private _catalogData;
+    get catalogData(): EcrpublicRepositoryCatalogDataOutputReference;
+    putCatalogData(value: EcrpublicRepositoryCatalogData): void;
+    resetCatalogData(): void;
+    get catalogDataInput(): EcrpublicRepositoryCatalogData | undefined;
+    private _timeouts;
+    get timeouts(): EcrpublicRepositoryTimeoutsOutputReference;
+    putTimeouts(value: EcrpublicRepositoryTimeouts): void;
+    resetTimeouts(): void;
+    get timeoutsInput(): cdktf.IResolvable | EcrpublicRepositoryTimeouts | undefined;
+    protected synthesizeAttributes(): {
+        [name: string]: any;
+    };
+    protected synthesizeHclAttributes(): {
+        [name: string]: any;
+    };
+}

--- a/data/reference/merged/provider-aws/imagebuilder-image/index.d.ts
+++ b/data/reference/merged/provider-aws/imagebuilder-image/index.d.ts
@@ -1,0 +1,465 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+import { Construct } from 'constructs';
+import * as cdktf from 'cdktf';
+export interface ImagebuilderImageConfig extends cdktf.TerraformMetaArguments {
+    /** (Optional) - Amazon Resource Name (ARN) of the container recipe. */
+    readonly containerRecipeArn?: string;
+    /** (Optional) Amazon Resource Name (ARN) of the Image Builder Distribution Configuration. */
+    readonly distributionConfigurationArn?: string;
+    /** (Optional) Whether additional information about the image being created is collected. Defaults to `true`. */
+    readonly enhancedImageMetadataEnabled?: boolean | cdktf.IResolvable;
+    /** (Optional) Amazon Resource Name (ARN) of the service-linked role to be used by Image Builder to [execute workflows](https://docs.aws.amazon.com/imagebuilder/latest/userguide/manage-image-workflows.html). */
+    readonly executionRole?: string;
+    /** */
+    readonly id?: string;
+    /** (Optional) Amazon Resource Name (ARN) of the image recipe. */
+    readonly imageRecipeArn?: string;
+    /** (Required) Amazon Resource Name (ARN) of the Image Builder Infrastructure Configuration. */
+    readonly infrastructureConfigurationArn: string;
+    /** (Optional) Key-value map of resource tags for the Image Builder Image. If configured with a provider [`defaultTags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level. */
+    readonly tags?: {
+        [key: string]: string;
+    };
+    /** */
+    readonly tagsAll?: {
+        [key: string]: string;
+    };
+    /** */
+    readonly imageScanningConfiguration?: ImagebuilderImageImageScanningConfiguration;
+    /** */
+    readonly imageTestsConfiguration?: ImagebuilderImageImageTestsConfiguration;
+    /** */
+    readonly timeouts?: ImagebuilderImageTimeouts;
+    /** */
+    readonly workflow?: ImagebuilderImageWorkflow[] | cdktf.IResolvable;
+}
+export interface ImagebuilderImageOutputResourcesAmis {
+}
+export declare function imagebuilderImageOutputResourcesAmisToTerraform(struct?: ImagebuilderImageOutputResourcesAmis): any;
+export declare function imagebuilderImageOutputResourcesAmisToHclTerraform(struct?: ImagebuilderImageOutputResourcesAmis): any;
+export declare class ImagebuilderImageOutputResourcesAmisOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    * @param complexObjectIndex the index of this item in the list
+    * @param complexObjectIsFromSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string, complexObjectIndex: number, complexObjectIsFromSet: boolean);
+    get internalValue(): ImagebuilderImageOutputResourcesAmis | undefined;
+    set internalValue(value: ImagebuilderImageOutputResourcesAmis | undefined);
+    get accountId(): string;
+    get description(): string;
+    get image(): string;
+    get name(): string;
+    get region(): string;
+}
+export declare class ImagebuilderImageOutputResourcesAmisList extends cdktf.ComplexList {
+    protected terraformResource: cdktf.IInterpolatingParent;
+    protected terraformAttribute: string;
+    protected wrapsSet: boolean;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    * @param wrapsSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string, wrapsSet: boolean);
+    /**
+    * @param index the index of the item to return
+    */
+    get(index: number): ImagebuilderImageOutputResourcesAmisOutputReference;
+}
+export interface ImagebuilderImageOutputResourcesContainers {
+}
+export declare function imagebuilderImageOutputResourcesContainersToTerraform(struct?: ImagebuilderImageOutputResourcesContainers): any;
+export declare function imagebuilderImageOutputResourcesContainersToHclTerraform(struct?: ImagebuilderImageOutputResourcesContainers): any;
+export declare class ImagebuilderImageOutputResourcesContainersOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    * @param complexObjectIndex the index of this item in the list
+    * @param complexObjectIsFromSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string, complexObjectIndex: number, complexObjectIsFromSet: boolean);
+    get internalValue(): ImagebuilderImageOutputResourcesContainers | undefined;
+    set internalValue(value: ImagebuilderImageOutputResourcesContainers | undefined);
+    get imageUris(): string[];
+    get region(): string;
+}
+export declare class ImagebuilderImageOutputResourcesContainersList extends cdktf.ComplexList {
+    protected terraformResource: cdktf.IInterpolatingParent;
+    protected terraformAttribute: string;
+    protected wrapsSet: boolean;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    * @param wrapsSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string, wrapsSet: boolean);
+    /**
+    * @param index the index of the item to return
+    */
+    get(index: number): ImagebuilderImageOutputResourcesContainersOutputReference;
+}
+export interface ImagebuilderImageOutputResources {
+}
+export declare function imagebuilderImageOutputResourcesToTerraform(struct?: ImagebuilderImageOutputResources): any;
+export declare function imagebuilderImageOutputResourcesToHclTerraform(struct?: ImagebuilderImageOutputResources): any;
+export declare class ImagebuilderImageOutputResourcesOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    * @param complexObjectIndex the index of this item in the list
+    * @param complexObjectIsFromSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string, complexObjectIndex: number, complexObjectIsFromSet: boolean);
+    get internalValue(): ImagebuilderImageOutputResources | undefined;
+    set internalValue(value: ImagebuilderImageOutputResources | undefined);
+    private _amis;
+    get amis(): ImagebuilderImageOutputResourcesAmisList;
+    private _containers;
+    get containers(): ImagebuilderImageOutputResourcesContainersList;
+}
+export declare class ImagebuilderImageOutputResourcesList extends cdktf.ComplexList {
+    protected terraformResource: cdktf.IInterpolatingParent;
+    protected terraformAttribute: string;
+    protected wrapsSet: boolean;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    * @param wrapsSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string, wrapsSet: boolean);
+    /**
+    * @param index the index of the item to return
+    */
+    get(index: number): ImagebuilderImageOutputResourcesOutputReference;
+}
+export interface ImagebuilderImageImageScanningConfigurationEcrConfiguration {
+    /** (Optional) Set of tags for Image Builder to apply to the output container image that that Amazon Inspector scans. */
+    readonly containerTags?: string[];
+    /** (Optional) The name of the container repository that Amazon Inspector scans to identify findings for your container images. */
+    readonly repositoryName?: string;
+}
+export declare function imagebuilderImageImageScanningConfigurationEcrConfigurationToTerraform(struct?: ImagebuilderImageImageScanningConfigurationEcrConfigurationOutputReference | ImagebuilderImageImageScanningConfigurationEcrConfiguration): any;
+export declare function imagebuilderImageImageScanningConfigurationEcrConfigurationToHclTerraform(struct?: ImagebuilderImageImageScanningConfigurationEcrConfigurationOutputReference | ImagebuilderImageImageScanningConfigurationEcrConfiguration): any;
+export declare class ImagebuilderImageImageScanningConfigurationEcrConfigurationOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): ImagebuilderImageImageScanningConfigurationEcrConfiguration | undefined;
+    set internalValue(value: ImagebuilderImageImageScanningConfigurationEcrConfiguration | undefined);
+    private _containerTags?;
+    get containerTags(): string[];
+    set containerTags(value: string[]);
+    resetContainerTags(): void;
+    get containerTagsInput(): string[] | undefined;
+    private _repositoryName?;
+    get repositoryName(): string;
+    set repositoryName(value: string);
+    resetRepositoryName(): void;
+    get repositoryNameInput(): string | undefined;
+}
+export interface ImagebuilderImageImageScanningConfiguration {
+    /** (Optional) Indicates whether Image Builder keeps a snapshot of the vulnerability scans that Amazon Inspector runs against the build instance when you create a new image. Defaults to `false`. */
+    readonly imageScanningEnabled?: boolean | cdktf.IResolvable;
+    /** */
+    readonly ecrConfiguration?: ImagebuilderImageImageScanningConfigurationEcrConfiguration;
+}
+export declare function imagebuilderImageImageScanningConfigurationToTerraform(struct?: ImagebuilderImageImageScanningConfigurationOutputReference | ImagebuilderImageImageScanningConfiguration): any;
+export declare function imagebuilderImageImageScanningConfigurationToHclTerraform(struct?: ImagebuilderImageImageScanningConfigurationOutputReference | ImagebuilderImageImageScanningConfiguration): any;
+export declare class ImagebuilderImageImageScanningConfigurationOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): ImagebuilderImageImageScanningConfiguration | undefined;
+    set internalValue(value: ImagebuilderImageImageScanningConfiguration | undefined);
+    private _imageScanningEnabled?;
+    get imageScanningEnabled(): boolean | cdktf.IResolvable;
+    set imageScanningEnabled(value: boolean | cdktf.IResolvable);
+    resetImageScanningEnabled(): void;
+    get imageScanningEnabledInput(): boolean | cdktf.IResolvable | undefined;
+    private _ecrConfiguration;
+    get ecrConfiguration(): ImagebuilderImageImageScanningConfigurationEcrConfigurationOutputReference;
+    putEcrConfiguration(value: ImagebuilderImageImageScanningConfigurationEcrConfiguration): void;
+    resetEcrConfiguration(): void;
+    get ecrConfigurationInput(): ImagebuilderImageImageScanningConfigurationEcrConfiguration | undefined;
+}
+export interface ImagebuilderImageImageTestsConfiguration {
+    /** (Optional) Whether image tests are enabled. Defaults to `true`. */
+    readonly imageTestsEnabled?: boolean | cdktf.IResolvable;
+    /** (Optional) Number of minutes before image tests time out. Valid values are between `60` and `1440`. Defaults to `720`. */
+    readonly timeoutMinutes?: number;
+}
+export declare function imagebuilderImageImageTestsConfigurationToTerraform(struct?: ImagebuilderImageImageTestsConfigurationOutputReference | ImagebuilderImageImageTestsConfiguration): any;
+export declare function imagebuilderImageImageTestsConfigurationToHclTerraform(struct?: ImagebuilderImageImageTestsConfigurationOutputReference | ImagebuilderImageImageTestsConfiguration): any;
+export declare class ImagebuilderImageImageTestsConfigurationOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): ImagebuilderImageImageTestsConfiguration | undefined;
+    set internalValue(value: ImagebuilderImageImageTestsConfiguration | undefined);
+    private _imageTestsEnabled?;
+    get imageTestsEnabled(): boolean | cdktf.IResolvable;
+    set imageTestsEnabled(value: boolean | cdktf.IResolvable);
+    resetImageTestsEnabled(): void;
+    get imageTestsEnabledInput(): boolean | cdktf.IResolvable | undefined;
+    private _timeoutMinutes?;
+    get timeoutMinutes(): number;
+    set timeoutMinutes(value: number);
+    resetTimeoutMinutes(): void;
+    get timeoutMinutesInput(): number | undefined;
+}
+export interface ImagebuilderImageTimeouts {
+    /** (Default `60m`) */
+    readonly create?: string;
+}
+export declare function imagebuilderImageTimeoutsToTerraform(struct?: ImagebuilderImageTimeouts | cdktf.IResolvable): any;
+export declare function imagebuilderImageTimeoutsToHclTerraform(struct?: ImagebuilderImageTimeouts | cdktf.IResolvable): any;
+export declare class ImagebuilderImageTimeoutsOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    private resolvableValue?;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): ImagebuilderImageTimeouts | cdktf.IResolvable | undefined;
+    set internalValue(value: ImagebuilderImageTimeouts | cdktf.IResolvable | undefined);
+    private _create?;
+    get create(): string;
+    set create(value: string);
+    resetCreate(): void;
+    get createInput(): string | undefined;
+}
+export interface ImagebuilderImageWorkflowParameter {
+    /** (Required) The name of the Workflow parameter. */
+    readonly name: string;
+    /** (Required) The value of the Workflow parameter. */
+    readonly value: string;
+}
+export declare function imagebuilderImageWorkflowParameterToTerraform(struct?: ImagebuilderImageWorkflowParameter | cdktf.IResolvable): any;
+export declare function imagebuilderImageWorkflowParameterToHclTerraform(struct?: ImagebuilderImageWorkflowParameter | cdktf.IResolvable): any;
+export declare class ImagebuilderImageWorkflowParameterOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    private resolvableValue?;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    * @param complexObjectIndex the index of this item in the list
+    * @param complexObjectIsFromSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string, complexObjectIndex: number, complexObjectIsFromSet: boolean);
+    get internalValue(): ImagebuilderImageWorkflowParameter | cdktf.IResolvable | undefined;
+    set internalValue(value: ImagebuilderImageWorkflowParameter | cdktf.IResolvable | undefined);
+    private _name?;
+    get name(): string;
+    set name(value: string);
+    get nameInput(): string | undefined;
+    private _value?;
+    get value(): string;
+    set value(value: string);
+    get valueInput(): string | undefined;
+}
+export declare class ImagebuilderImageWorkflowParameterList extends cdktf.ComplexList {
+    protected terraformResource: cdktf.IInterpolatingParent;
+    protected terraformAttribute: string;
+    protected wrapsSet: boolean;
+    internalValue?: ImagebuilderImageWorkflowParameter[] | cdktf.IResolvable;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    * @param wrapsSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string, wrapsSet: boolean);
+    /**
+    * @param index the index of the item to return
+    */
+    get(index: number): ImagebuilderImageWorkflowParameterOutputReference;
+}
+export interface ImagebuilderImageWorkflow {
+    /** (Optional) The action to take if the workflow fails. Must be one of `CONTINUE` or `ABORT`. */
+    readonly onFailure?: string;
+    /** (Optional) The parallel group in which to run a test Workflow. */
+    readonly parallelGroup?: string;
+    /** (Required) Amazon Resource Name (ARN) of the Image Builder Workflow. */
+    readonly workflowArn: string;
+    /** */
+    readonly parameter?: ImagebuilderImageWorkflowParameter[] | cdktf.IResolvable;
+}
+export declare function imagebuilderImageWorkflowToTerraform(struct?: ImagebuilderImageWorkflow | cdktf.IResolvable): any;
+export declare function imagebuilderImageWorkflowToHclTerraform(struct?: ImagebuilderImageWorkflow | cdktf.IResolvable): any;
+export declare class ImagebuilderImageWorkflowOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    private resolvableValue?;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    * @param complexObjectIndex the index of this item in the list
+    * @param complexObjectIsFromSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string, complexObjectIndex: number, complexObjectIsFromSet: boolean);
+    get internalValue(): ImagebuilderImageWorkflow | cdktf.IResolvable | undefined;
+    set internalValue(value: ImagebuilderImageWorkflow | cdktf.IResolvable | undefined);
+    private _onFailure?;
+    get onFailure(): string;
+    set onFailure(value: string);
+    resetOnFailure(): void;
+    get onFailureInput(): string | undefined;
+    private _parallelGroup?;
+    get parallelGroup(): string;
+    set parallelGroup(value: string);
+    resetParallelGroup(): void;
+    get parallelGroupInput(): string | undefined;
+    private _workflowArn?;
+    get workflowArn(): string;
+    set workflowArn(value: string);
+    get workflowArnInput(): string | undefined;
+    private _parameter;
+    get parameter(): ImagebuilderImageWorkflowParameterList;
+    putParameter(value: ImagebuilderImageWorkflowParameter[] | cdktf.IResolvable): void;
+    resetParameter(): void;
+    get parameterInput(): cdktf.IResolvable | ImagebuilderImageWorkflowParameter[] | undefined;
+}
+export declare class ImagebuilderImageWorkflowList extends cdktf.ComplexList {
+    protected terraformResource: cdktf.IInterpolatingParent;
+    protected terraformAttribute: string;
+    protected wrapsSet: boolean;
+    internalValue?: ImagebuilderImageWorkflow[] | cdktf.IResolvable;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    * @param wrapsSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string, wrapsSet: boolean);
+    /**
+    * @param index the index of the item to return
+    */
+    get(index: number): ImagebuilderImageWorkflowOutputReference;
+}
+/**
+* Represents a {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/imagebuilder_image aws_imagebuilder_image}
+*/
+export declare class ImagebuilderImage extends cdktf.TerraformResource {
+    static readonly tfResourceType = "aws_imagebuilder_image";
+    /**
+    * Generates CDKTF code for importing a ImagebuilderImage resource upon running "cdktf plan <stack-name>"
+    * @param scope The scope in which to define this construct
+    * @param importToId The construct id used in the generated config for the ImagebuilderImage to import
+    * @param importFromId The id of the existing ImagebuilderImage that should be imported. Refer to the {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/imagebuilder_image#import import section} in the documentation of this resource for the id to use
+    * @param provider? Optional instance of the provider where the ImagebuilderImage to import is found
+    */
+    static generateConfigForImport(scope: Construct, importToId: string, importFromId: string, provider?: cdktf.TerraformProvider): cdktf.ImportableResource;
+    /**
+    * Create a new {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/imagebuilder_image aws_imagebuilder_image} Resource
+    *
+    * @param scope The scope in which to define this construct
+    * @param id The scoped construct ID. Must be unique amongst siblings in the same scope
+    * @param options ImagebuilderImageConfig
+    */
+    constructor(scope: Construct, id: string, config: ImagebuilderImageConfig);
+    get arn(): string;
+    private _containerRecipeArn?;
+    get containerRecipeArn(): string;
+    set containerRecipeArn(value: string);
+    resetContainerRecipeArn(): void;
+    get containerRecipeArnInput(): string | undefined;
+    get dateCreated(): string;
+    private _distributionConfigurationArn?;
+    get distributionConfigurationArn(): string;
+    set distributionConfigurationArn(value: string);
+    resetDistributionConfigurationArn(): void;
+    get distributionConfigurationArnInput(): string | undefined;
+    private _enhancedImageMetadataEnabled?;
+    get enhancedImageMetadataEnabled(): boolean | cdktf.IResolvable;
+    set enhancedImageMetadataEnabled(value: boolean | cdktf.IResolvable);
+    resetEnhancedImageMetadataEnabled(): void;
+    get enhancedImageMetadataEnabledInput(): boolean | cdktf.IResolvable | undefined;
+    private _executionRole?;
+    get executionRole(): string;
+    set executionRole(value: string);
+    resetExecutionRole(): void;
+    get executionRoleInput(): string | undefined;
+    private _id?;
+    get id(): string;
+    set id(value: string);
+    resetId(): void;
+    get idInput(): string | undefined;
+    private _imageRecipeArn?;
+    get imageRecipeArn(): string;
+    set imageRecipeArn(value: string);
+    resetImageRecipeArn(): void;
+    get imageRecipeArnInput(): string | undefined;
+    private _infrastructureConfigurationArn?;
+    get infrastructureConfigurationArn(): string;
+    set infrastructureConfigurationArn(value: string);
+    get infrastructureConfigurationArnInput(): string | undefined;
+    get name(): string;
+    get osVersion(): string;
+    private _outputResources;
+    get outputResources(): ImagebuilderImageOutputResourcesList;
+    get platform(): string;
+    private _tags?;
+    get tags(): {
+        [key: string]: string;
+    };
+    set tags(value: {
+        [key: string]: string;
+    });
+    resetTags(): void;
+    get tagsInput(): {
+        [key: string]: string;
+    } | undefined;
+    private _tagsAll?;
+    get tagsAll(): {
+        [key: string]: string;
+    };
+    set tagsAll(value: {
+        [key: string]: string;
+    });
+    resetTagsAll(): void;
+    get tagsAllInput(): {
+        [key: string]: string;
+    } | undefined;
+    get version(): string;
+    private _imageScanningConfiguration;
+    get imageScanningConfiguration(): ImagebuilderImageImageScanningConfigurationOutputReference;
+    putImageScanningConfiguration(value: ImagebuilderImageImageScanningConfiguration): void;
+    resetImageScanningConfiguration(): void;
+    get imageScanningConfigurationInput(): ImagebuilderImageImageScanningConfiguration | undefined;
+    private _imageTestsConfiguration;
+    get imageTestsConfiguration(): ImagebuilderImageImageTestsConfigurationOutputReference;
+    putImageTestsConfiguration(value: ImagebuilderImageImageTestsConfiguration): void;
+    resetImageTestsConfiguration(): void;
+    get imageTestsConfigurationInput(): ImagebuilderImageImageTestsConfiguration | undefined;
+    private _timeouts;
+    get timeouts(): ImagebuilderImageTimeoutsOutputReference;
+    putTimeouts(value: ImagebuilderImageTimeouts): void;
+    resetTimeouts(): void;
+    get timeoutsInput(): cdktf.IResolvable | ImagebuilderImageTimeouts | undefined;
+    private _workflow;
+    get workflow(): ImagebuilderImageWorkflowList;
+    putWorkflow(value: ImagebuilderImageWorkflow[] | cdktf.IResolvable): void;
+    resetWorkflow(): void;
+    get workflowInput(): cdktf.IResolvable | ImagebuilderImageWorkflow[] | undefined;
+    protected synthesizeAttributes(): {
+        [name: string]: any;
+    };
+    protected synthesizeHclAttributes(): {
+        [name: string]: any;
+    };
+}

--- a/data/reference/merged/provider-aws/kinesis-firehose-delivery-stream/index.d.ts
+++ b/data/reference/merged/provider-aws/kinesis-firehose-delivery-stream/index.d.ts
@@ -1,0 +1,5109 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+import { Construct } from 'constructs';
+import * as cdktf from 'cdktf';
+export interface KinesisFirehoseDeliveryStreamConfig extends cdktf.TerraformMetaArguments {
+    /** */
+    readonly arn?: string;
+    /** (Required) This is the destination to where the data is delivered. The only options are `s3` (Deprecated, use `extended_s3` instead), `extended_s3`, `redshift`, `elasticsearch`, `splunk`, `httpEndpoint`, `opensearch`, `opensearchserverless` and `snowflake`. */
+    readonly destination: string;
+    /** */
+    readonly destinationId?: string;
+    /** */
+    readonly id?: string;
+    /** (Required) A name to identify the stream. This is unique to the AWS account and region the Stream is created in. When using for WAF logging, name must be prefixed with `aws-waf-logs-`. See [AWS Documentation](https://docs.aws.amazon.com/waf/latest/developerguide/waf-policies.html#waf-policies-logging-config) for more details. */
+    readonly name: string;
+    /** (Optional) A map of tags to assign to the resource. If configured with a provider [`defaultTags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level. */
+    readonly tags?: {
+        [key: string]: string;
+    };
+    /** */
+    readonly tagsAll?: {
+        [key: string]: string;
+    };
+    /** (Optional) Specifies the table version for the output data schema. Defaults to `LATEST`. */
+    readonly versionId?: string;
+    /** */
+    readonly elasticsearchConfiguration?: KinesisFirehoseDeliveryStreamElasticsearchConfiguration;
+    /** */
+    readonly extendedS3Configuration?: KinesisFirehoseDeliveryStreamExtendedS3Configuration;
+    /** */
+    readonly httpEndpointConfiguration?: KinesisFirehoseDeliveryStreamHttpEndpointConfiguration;
+    /** */
+    readonly icebergConfiguration?: KinesisFirehoseDeliveryStreamIcebergConfiguration;
+    /** */
+    readonly kinesisSourceConfiguration?: KinesisFirehoseDeliveryStreamKinesisSourceConfiguration;
+    /** */
+    readonly mskSourceConfiguration?: KinesisFirehoseDeliveryStreamMskSourceConfiguration;
+    /** */
+    readonly opensearchConfiguration?: KinesisFirehoseDeliveryStreamOpensearchConfiguration;
+    /** */
+    readonly opensearchserverlessConfiguration?: KinesisFirehoseDeliveryStreamOpensearchserverlessConfiguration;
+    /** */
+    readonly redshiftConfiguration?: KinesisFirehoseDeliveryStreamRedshiftConfiguration;
+    /** */
+    readonly serverSideEncryption?: KinesisFirehoseDeliveryStreamServerSideEncryption;
+    /** */
+    readonly snowflakeConfiguration?: KinesisFirehoseDeliveryStreamSnowflakeConfiguration;
+    /** */
+    readonly splunkConfiguration?: KinesisFirehoseDeliveryStreamSplunkConfiguration;
+    /** */
+    readonly timeouts?: KinesisFirehoseDeliveryStreamTimeouts;
+}
+export interface KinesisFirehoseDeliveryStreamElasticsearchConfigurationCloudwatchLoggingOptions {
+    /** (Optional) Enables or disables the logging. Defaults to `false`. */
+    readonly enabled?: boolean | cdktf.IResolvable;
+    /** (Optional) The CloudWatch group name for logging. This value is required if `enabled` is true. */
+    readonly logGroupName?: string;
+    /** (Optional) The CloudWatch log stream name for logging. This value is required if `enabled` is true. */
+    readonly logStreamName?: string;
+}
+export declare function kinesisFirehoseDeliveryStreamElasticsearchConfigurationCloudwatchLoggingOptionsToTerraform(struct?: KinesisFirehoseDeliveryStreamElasticsearchConfigurationCloudwatchLoggingOptionsOutputReference | KinesisFirehoseDeliveryStreamElasticsearchConfigurationCloudwatchLoggingOptions): any;
+export declare function kinesisFirehoseDeliveryStreamElasticsearchConfigurationCloudwatchLoggingOptionsToHclTerraform(struct?: KinesisFirehoseDeliveryStreamElasticsearchConfigurationCloudwatchLoggingOptionsOutputReference | KinesisFirehoseDeliveryStreamElasticsearchConfigurationCloudwatchLoggingOptions): any;
+export declare class KinesisFirehoseDeliveryStreamElasticsearchConfigurationCloudwatchLoggingOptionsOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamElasticsearchConfigurationCloudwatchLoggingOptions | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamElasticsearchConfigurationCloudwatchLoggingOptions | undefined);
+    private _enabled?;
+    get enabled(): boolean | cdktf.IResolvable;
+    set enabled(value: boolean | cdktf.IResolvable);
+    resetEnabled(): void;
+    get enabledInput(): boolean | cdktf.IResolvable | undefined;
+    private _logGroupName?;
+    get logGroupName(): string;
+    set logGroupName(value: string);
+    resetLogGroupName(): void;
+    get logGroupNameInput(): string | undefined;
+    private _logStreamName?;
+    get logStreamName(): string;
+    set logStreamName(value: string);
+    resetLogStreamName(): void;
+    get logStreamNameInput(): string | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamElasticsearchConfigurationProcessingConfigurationProcessorsParameters {
+    /** (Required) Parameter name. Valid Values: `LambdaArn`, `NumberOfRetries`, `MetadataExtractionQuery`, `JsonParsingEngine`, `RoleArn`, `BufferSizeInMBs`, `BufferIntervalInSeconds`, `SubRecordType`, `Delimiter`, `CompressionFormat`, `DataMessageExtraction`. Validation is done against [AWS SDK constants](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/firehose/types#ProcessorParameterName); so values not explicitly listed may also work. */
+    readonly parameterName: string;
+    /** (Required) Parameter value. Must be between 1 and 512 length (inclusive). When providing a Lambda ARN, you should specify the resource version as well. */
+    readonly parameterValue: string;
+}
+export declare function kinesisFirehoseDeliveryStreamElasticsearchConfigurationProcessingConfigurationProcessorsParametersToTerraform(struct?: KinesisFirehoseDeliveryStreamElasticsearchConfigurationProcessingConfigurationProcessorsParameters | cdktf.IResolvable): any;
+export declare function kinesisFirehoseDeliveryStreamElasticsearchConfigurationProcessingConfigurationProcessorsParametersToHclTerraform(struct?: KinesisFirehoseDeliveryStreamElasticsearchConfigurationProcessingConfigurationProcessorsParameters | cdktf.IResolvable): any;
+export declare class KinesisFirehoseDeliveryStreamElasticsearchConfigurationProcessingConfigurationProcessorsParametersOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    private resolvableValue?;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    * @param complexObjectIndex the index of this item in the list
+    * @param complexObjectIsFromSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string, complexObjectIndex: number, complexObjectIsFromSet: boolean);
+    get internalValue(): KinesisFirehoseDeliveryStreamElasticsearchConfigurationProcessingConfigurationProcessorsParameters | cdktf.IResolvable | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamElasticsearchConfigurationProcessingConfigurationProcessorsParameters | cdktf.IResolvable | undefined);
+    private _parameterName?;
+    get parameterName(): string;
+    set parameterName(value: string);
+    get parameterNameInput(): string | undefined;
+    private _parameterValue?;
+    get parameterValue(): string;
+    set parameterValue(value: string);
+    get parameterValueInput(): string | undefined;
+}
+export declare class KinesisFirehoseDeliveryStreamElasticsearchConfigurationProcessingConfigurationProcessorsParametersList extends cdktf.ComplexList {
+    protected terraformResource: cdktf.IInterpolatingParent;
+    protected terraformAttribute: string;
+    protected wrapsSet: boolean;
+    internalValue?: KinesisFirehoseDeliveryStreamElasticsearchConfigurationProcessingConfigurationProcessorsParameters[] | cdktf.IResolvable;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    * @param wrapsSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string, wrapsSet: boolean);
+    /**
+    * @param index the index of the item to return
+    */
+    get(index: number): KinesisFirehoseDeliveryStreamElasticsearchConfigurationProcessingConfigurationProcessorsParametersOutputReference;
+}
+export interface KinesisFirehoseDeliveryStreamElasticsearchConfigurationProcessingConfigurationProcessors {
+    /** (Required) The type of processor. Valid Values: `RecordDeAggregation`, `Lambda`, `MetadataExtraction`, `AppendDelimiterToRecord`, `Decompression`, `CloudWatchLogProcessing`. Validation is done against [AWS SDK constants](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/firehose/types#ProcessorType); so values not explicitly listed may also work. */
+    readonly type: string;
+    /** */
+    readonly parameters?: KinesisFirehoseDeliveryStreamElasticsearchConfigurationProcessingConfigurationProcessorsParameters[] | cdktf.IResolvable;
+}
+export declare function kinesisFirehoseDeliveryStreamElasticsearchConfigurationProcessingConfigurationProcessorsToTerraform(struct?: KinesisFirehoseDeliveryStreamElasticsearchConfigurationProcessingConfigurationProcessors | cdktf.IResolvable): any;
+export declare function kinesisFirehoseDeliveryStreamElasticsearchConfigurationProcessingConfigurationProcessorsToHclTerraform(struct?: KinesisFirehoseDeliveryStreamElasticsearchConfigurationProcessingConfigurationProcessors | cdktf.IResolvable): any;
+export declare class KinesisFirehoseDeliveryStreamElasticsearchConfigurationProcessingConfigurationProcessorsOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    private resolvableValue?;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    * @param complexObjectIndex the index of this item in the list
+    * @param complexObjectIsFromSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string, complexObjectIndex: number, complexObjectIsFromSet: boolean);
+    get internalValue(): KinesisFirehoseDeliveryStreamElasticsearchConfigurationProcessingConfigurationProcessors | cdktf.IResolvable | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamElasticsearchConfigurationProcessingConfigurationProcessors | cdktf.IResolvable | undefined);
+    private _type?;
+    get type(): string;
+    set type(value: string);
+    get typeInput(): string | undefined;
+    private _parameters;
+    get parameters(): KinesisFirehoseDeliveryStreamElasticsearchConfigurationProcessingConfigurationProcessorsParametersList;
+    putParameters(value: KinesisFirehoseDeliveryStreamElasticsearchConfigurationProcessingConfigurationProcessorsParameters[] | cdktf.IResolvable): void;
+    resetParameters(): void;
+    get parametersInput(): cdktf.IResolvable | KinesisFirehoseDeliveryStreamElasticsearchConfigurationProcessingConfigurationProcessorsParameters[] | undefined;
+}
+export declare class KinesisFirehoseDeliveryStreamElasticsearchConfigurationProcessingConfigurationProcessorsList extends cdktf.ComplexList {
+    protected terraformResource: cdktf.IInterpolatingParent;
+    protected terraformAttribute: string;
+    protected wrapsSet: boolean;
+    internalValue?: KinesisFirehoseDeliveryStreamElasticsearchConfigurationProcessingConfigurationProcessors[] | cdktf.IResolvable;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    * @param wrapsSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string, wrapsSet: boolean);
+    /**
+    * @param index the index of the item to return
+    */
+    get(index: number): KinesisFirehoseDeliveryStreamElasticsearchConfigurationProcessingConfigurationProcessorsOutputReference;
+}
+export interface KinesisFirehoseDeliveryStreamElasticsearchConfigurationProcessingConfiguration {
+    /** (Optional) Enables or disables data processing. */
+    readonly enabled?: boolean | cdktf.IResolvable;
+    /** */
+    readonly processors?: KinesisFirehoseDeliveryStreamElasticsearchConfigurationProcessingConfigurationProcessors[] | cdktf.IResolvable;
+}
+export declare function kinesisFirehoseDeliveryStreamElasticsearchConfigurationProcessingConfigurationToTerraform(struct?: KinesisFirehoseDeliveryStreamElasticsearchConfigurationProcessingConfigurationOutputReference | KinesisFirehoseDeliveryStreamElasticsearchConfigurationProcessingConfiguration): any;
+export declare function kinesisFirehoseDeliveryStreamElasticsearchConfigurationProcessingConfigurationToHclTerraform(struct?: KinesisFirehoseDeliveryStreamElasticsearchConfigurationProcessingConfigurationOutputReference | KinesisFirehoseDeliveryStreamElasticsearchConfigurationProcessingConfiguration): any;
+export declare class KinesisFirehoseDeliveryStreamElasticsearchConfigurationProcessingConfigurationOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamElasticsearchConfigurationProcessingConfiguration | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamElasticsearchConfigurationProcessingConfiguration | undefined);
+    private _enabled?;
+    get enabled(): boolean | cdktf.IResolvable;
+    set enabled(value: boolean | cdktf.IResolvable);
+    resetEnabled(): void;
+    get enabledInput(): boolean | cdktf.IResolvable | undefined;
+    private _processors;
+    get processors(): KinesisFirehoseDeliveryStreamElasticsearchConfigurationProcessingConfigurationProcessorsList;
+    putProcessors(value: KinesisFirehoseDeliveryStreamElasticsearchConfigurationProcessingConfigurationProcessors[] | cdktf.IResolvable): void;
+    resetProcessors(): void;
+    get processorsInput(): cdktf.IResolvable | KinesisFirehoseDeliveryStreamElasticsearchConfigurationProcessingConfigurationProcessors[] | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamElasticsearchConfigurationS3ConfigurationCloudwatchLoggingOptions {
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#enabled KinesisFirehoseDeliveryStream#enabled}
+    */
+    readonly enabled?: boolean | cdktf.IResolvable;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#log_group_name KinesisFirehoseDeliveryStream#log_group_name}
+    */
+    readonly logGroupName?: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#log_stream_name KinesisFirehoseDeliveryStream#log_stream_name}
+    */
+    readonly logStreamName?: string;
+}
+export declare function kinesisFirehoseDeliveryStreamElasticsearchConfigurationS3ConfigurationCloudwatchLoggingOptionsToTerraform(struct?: KinesisFirehoseDeliveryStreamElasticsearchConfigurationS3ConfigurationCloudwatchLoggingOptionsOutputReference | KinesisFirehoseDeliveryStreamElasticsearchConfigurationS3ConfigurationCloudwatchLoggingOptions): any;
+export declare function kinesisFirehoseDeliveryStreamElasticsearchConfigurationS3ConfigurationCloudwatchLoggingOptionsToHclTerraform(struct?: KinesisFirehoseDeliveryStreamElasticsearchConfigurationS3ConfigurationCloudwatchLoggingOptionsOutputReference | KinesisFirehoseDeliveryStreamElasticsearchConfigurationS3ConfigurationCloudwatchLoggingOptions): any;
+export declare class KinesisFirehoseDeliveryStreamElasticsearchConfigurationS3ConfigurationCloudwatchLoggingOptionsOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamElasticsearchConfigurationS3ConfigurationCloudwatchLoggingOptions | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamElasticsearchConfigurationS3ConfigurationCloudwatchLoggingOptions | undefined);
+    private _enabled?;
+    get enabled(): boolean | cdktf.IResolvable;
+    set enabled(value: boolean | cdktf.IResolvable);
+    resetEnabled(): void;
+    get enabledInput(): boolean | cdktf.IResolvable | undefined;
+    private _logGroupName?;
+    get logGroupName(): string;
+    set logGroupName(value: string);
+    resetLogGroupName(): void;
+    get logGroupNameInput(): string | undefined;
+    private _logStreamName?;
+    get logStreamName(): string;
+    set logStreamName(value: string);
+    resetLogStreamName(): void;
+    get logStreamNameInput(): string | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamElasticsearchConfigurationS3Configuration {
+    /** (Required) The ARN of the S3 bucket */
+    readonly bucketArn: string;
+    /** (Optional) Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. The default value is 300 (5 minutes). */
+    readonly bufferingInterval?: number;
+    /** (Optional) Buffer incoming data to the specified size, in MBs, before delivering it to the destination. The default value is 5. */
+    readonly bufferingSize?: number;
+    /** (Optional) The compression format. If no value is specified, the default is `UNCOMPRESSED`. Other supported values are `GZIP`, `ZIP`, `Snappy`, & `HADOOP_SNAPPY`. */
+    readonly compressionFormat?: string;
+    /** (Optional) Prefix added to failed records before writing them to S3. Not currently supported for `redshift` destination. This prefix appears immediately following the bucket name. For information about how to specify this prefix, see [Custom Prefixes for Amazon S3 Objects](https://docs.aws.amazon.com/firehose/latest/dev/s3-prefixes.html). */
+    readonly errorOutputPrefix?: string;
+    /** (Optional) Specifies the KMS key ARN the stream will use to encrypt data. If not set, no encryption will be used. */
+    readonly kmsKeyArn?: string;
+    /** (Optional) The "YYYY/MM/DD/HH" time format prefix is automatically used for delivered S3 files. You can specify an extra prefix to be added in front of the time format prefix. Note that if the prefix ends with a slash, it appears as a folder in the S3 bucket */
+    readonly prefix?: string;
+    /** (Required) Kinesis Data Firehose uses this IAM role for all the permissions that the delivery stream needs. The pattern needs to be `arn:.*`. */
+    readonly roleArn: string;
+    /** */
+    readonly cloudwatchLoggingOptions?: KinesisFirehoseDeliveryStreamElasticsearchConfigurationS3ConfigurationCloudwatchLoggingOptions;
+}
+export declare function kinesisFirehoseDeliveryStreamElasticsearchConfigurationS3ConfigurationToTerraform(struct?: KinesisFirehoseDeliveryStreamElasticsearchConfigurationS3ConfigurationOutputReference | KinesisFirehoseDeliveryStreamElasticsearchConfigurationS3Configuration): any;
+export declare function kinesisFirehoseDeliveryStreamElasticsearchConfigurationS3ConfigurationToHclTerraform(struct?: KinesisFirehoseDeliveryStreamElasticsearchConfigurationS3ConfigurationOutputReference | KinesisFirehoseDeliveryStreamElasticsearchConfigurationS3Configuration): any;
+export declare class KinesisFirehoseDeliveryStreamElasticsearchConfigurationS3ConfigurationOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamElasticsearchConfigurationS3Configuration | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamElasticsearchConfigurationS3Configuration | undefined);
+    private _bucketArn?;
+    get bucketArn(): string;
+    set bucketArn(value: string);
+    get bucketArnInput(): string | undefined;
+    private _bufferingInterval?;
+    get bufferingInterval(): number;
+    set bufferingInterval(value: number);
+    resetBufferingInterval(): void;
+    get bufferingIntervalInput(): number | undefined;
+    private _bufferingSize?;
+    get bufferingSize(): number;
+    set bufferingSize(value: number);
+    resetBufferingSize(): void;
+    get bufferingSizeInput(): number | undefined;
+    private _compressionFormat?;
+    get compressionFormat(): string;
+    set compressionFormat(value: string);
+    resetCompressionFormat(): void;
+    get compressionFormatInput(): string | undefined;
+    private _errorOutputPrefix?;
+    get errorOutputPrefix(): string;
+    set errorOutputPrefix(value: string);
+    resetErrorOutputPrefix(): void;
+    get errorOutputPrefixInput(): string | undefined;
+    private _kmsKeyArn?;
+    get kmsKeyArn(): string;
+    set kmsKeyArn(value: string);
+    resetKmsKeyArn(): void;
+    get kmsKeyArnInput(): string | undefined;
+    private _prefix?;
+    get prefix(): string;
+    set prefix(value: string);
+    resetPrefix(): void;
+    get prefixInput(): string | undefined;
+    private _roleArn?;
+    get roleArn(): string;
+    set roleArn(value: string);
+    get roleArnInput(): string | undefined;
+    private _cloudwatchLoggingOptions;
+    get cloudwatchLoggingOptions(): KinesisFirehoseDeliveryStreamElasticsearchConfigurationS3ConfigurationCloudwatchLoggingOptionsOutputReference;
+    putCloudwatchLoggingOptions(value: KinesisFirehoseDeliveryStreamElasticsearchConfigurationS3ConfigurationCloudwatchLoggingOptions): void;
+    resetCloudwatchLoggingOptions(): void;
+    get cloudwatchLoggingOptionsInput(): KinesisFirehoseDeliveryStreamElasticsearchConfigurationS3ConfigurationCloudwatchLoggingOptions | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamElasticsearchConfigurationVpcConfig {
+    /** (Required) The ARN of the IAM role to be assumed by Firehose for calling the Amazon EC2 configuration API and for creating network interfaces. Make sure role has necessary [IAM permissions](https://docs.aws.amazon.com/firehose/latest/dev/controlling-access.html#using-iam-es-vpc) */
+    readonly roleArn: string;
+    /** (Required) A list of security group IDs to associate with Kinesis Firehose. */
+    readonly securityGroupIds: string[];
+    /** (Required) A list of subnet IDs to associate with Kinesis Firehose. */
+    readonly subnetIds: string[];
+}
+export declare function kinesisFirehoseDeliveryStreamElasticsearchConfigurationVpcConfigToTerraform(struct?: KinesisFirehoseDeliveryStreamElasticsearchConfigurationVpcConfigOutputReference | KinesisFirehoseDeliveryStreamElasticsearchConfigurationVpcConfig): any;
+export declare function kinesisFirehoseDeliveryStreamElasticsearchConfigurationVpcConfigToHclTerraform(struct?: KinesisFirehoseDeliveryStreamElasticsearchConfigurationVpcConfigOutputReference | KinesisFirehoseDeliveryStreamElasticsearchConfigurationVpcConfig): any;
+export declare class KinesisFirehoseDeliveryStreamElasticsearchConfigurationVpcConfigOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamElasticsearchConfigurationVpcConfig | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamElasticsearchConfigurationVpcConfig | undefined);
+    private _roleArn?;
+    get roleArn(): string;
+    set roleArn(value: string);
+    get roleArnInput(): string | undefined;
+    private _securityGroupIds?;
+    get securityGroupIds(): string[];
+    set securityGroupIds(value: string[]);
+    get securityGroupIdsInput(): string[] | undefined;
+    private _subnetIds?;
+    get subnetIds(): string[];
+    set subnetIds(value: string[]);
+    get subnetIdsInput(): string[] | undefined;
+    get vpcId(): string;
+}
+export interface KinesisFirehoseDeliveryStreamElasticsearchConfiguration {
+    /** (Optional) Buffer incoming data for the specified period of time, in seconds between 0 to 900, before delivering it to the destination.  The default value is 300s. */
+    readonly bufferingInterval?: number;
+    /** (Optional) Buffer incoming data to the specified size, in MBs between 1 to 100, before delivering it to the destination.  The default value is 5MB. */
+    readonly bufferingSize?: number;
+    /** (Optional) The endpoint to use when communicating with the cluster. Conflicts with `domainArn`. */
+    readonly clusterEndpoint?: string;
+    /** (Optional) The ARN of the Amazon ES domain.  The pattern needs to be `arn:.*`.  Conflicts with `clusterEndpoint`. */
+    readonly domainArn?: string;
+    /** (Required) The Elasticsearch index name. */
+    readonly indexName: string;
+    /** (Optional) The Elasticsearch index rotation period.  Index rotation appends a timestamp to the IndexName to facilitate expiration of old data.  Valid values are `NoRotation`, `OneHour`, `OneDay`, `OneWeek`, and `OneMonth`.  The default value is `OneDay`. */
+    readonly indexRotationPeriod?: string;
+    /** (Optional) After an initial failure to deliver to Amazon Elasticsearch, the total amount of time, in seconds between 0 to 7200, during which Firehose re-attempts delivery (including the first attempt).  After this time has elapsed, the failed documents are written to Amazon S3.  The default value is 300s.  There will be no retry if the value is 0. */
+    readonly retryDuration?: number;
+    /** (Required) The ARN of the IAM role to be assumed by Firehose for calling the Amazon ES Configuration API and for indexing documents.  The IAM role must have permission for `DescribeElasticsearchDomain`, `DescribeElasticsearchDomains`, and `DescribeElasticsearchDomainConfig`.  The pattern needs to be `arn:.*`. */
+    readonly roleArn: string;
+    /** (Optional) Defines how documents should be delivered to Amazon S3.  Valid values are `FailedDocumentsOnly` and `AllDocuments`.  Default value is `FailedDocumentsOnly`. */
+    readonly s3BackupMode?: string;
+    /** (Optional) The Elasticsearch type name with maximum length of 100 characters. */
+    readonly typeName?: string;
+    /** */
+    readonly cloudwatchLoggingOptions?: KinesisFirehoseDeliveryStreamElasticsearchConfigurationCloudwatchLoggingOptions;
+    /** */
+    readonly processingConfiguration?: KinesisFirehoseDeliveryStreamElasticsearchConfigurationProcessingConfiguration;
+    /** */
+    readonly s3Configuration: KinesisFirehoseDeliveryStreamElasticsearchConfigurationS3Configuration;
+    /** */
+    readonly vpcConfig?: KinesisFirehoseDeliveryStreamElasticsearchConfigurationVpcConfig;
+}
+export declare function kinesisFirehoseDeliveryStreamElasticsearchConfigurationToTerraform(struct?: KinesisFirehoseDeliveryStreamElasticsearchConfigurationOutputReference | KinesisFirehoseDeliveryStreamElasticsearchConfiguration): any;
+export declare function kinesisFirehoseDeliveryStreamElasticsearchConfigurationToHclTerraform(struct?: KinesisFirehoseDeliveryStreamElasticsearchConfigurationOutputReference | KinesisFirehoseDeliveryStreamElasticsearchConfiguration): any;
+export declare class KinesisFirehoseDeliveryStreamElasticsearchConfigurationOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamElasticsearchConfiguration | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamElasticsearchConfiguration | undefined);
+    private _bufferingInterval?;
+    get bufferingInterval(): number;
+    set bufferingInterval(value: number);
+    resetBufferingInterval(): void;
+    get bufferingIntervalInput(): number | undefined;
+    private _bufferingSize?;
+    get bufferingSize(): number;
+    set bufferingSize(value: number);
+    resetBufferingSize(): void;
+    get bufferingSizeInput(): number | undefined;
+    private _clusterEndpoint?;
+    get clusterEndpoint(): string;
+    set clusterEndpoint(value: string);
+    resetClusterEndpoint(): void;
+    get clusterEndpointInput(): string | undefined;
+    private _domainArn?;
+    get domainArn(): string;
+    set domainArn(value: string);
+    resetDomainArn(): void;
+    get domainArnInput(): string | undefined;
+    private _indexName?;
+    get indexName(): string;
+    set indexName(value: string);
+    get indexNameInput(): string | undefined;
+    private _indexRotationPeriod?;
+    get indexRotationPeriod(): string;
+    set indexRotationPeriod(value: string);
+    resetIndexRotationPeriod(): void;
+    get indexRotationPeriodInput(): string | undefined;
+    private _retryDuration?;
+    get retryDuration(): number;
+    set retryDuration(value: number);
+    resetRetryDuration(): void;
+    get retryDurationInput(): number | undefined;
+    private _roleArn?;
+    get roleArn(): string;
+    set roleArn(value: string);
+    get roleArnInput(): string | undefined;
+    private _s3BackupMode?;
+    get s3BackupMode(): string;
+    set s3BackupMode(value: string);
+    resetS3BackupMode(): void;
+    get s3BackupModeInput(): string | undefined;
+    private _typeName?;
+    get typeName(): string;
+    set typeName(value: string);
+    resetTypeName(): void;
+    get typeNameInput(): string | undefined;
+    private _cloudwatchLoggingOptions;
+    get cloudwatchLoggingOptions(): KinesisFirehoseDeliveryStreamElasticsearchConfigurationCloudwatchLoggingOptionsOutputReference;
+    putCloudwatchLoggingOptions(value: KinesisFirehoseDeliveryStreamElasticsearchConfigurationCloudwatchLoggingOptions): void;
+    resetCloudwatchLoggingOptions(): void;
+    get cloudwatchLoggingOptionsInput(): KinesisFirehoseDeliveryStreamElasticsearchConfigurationCloudwatchLoggingOptions | undefined;
+    private _processingConfiguration;
+    get processingConfiguration(): KinesisFirehoseDeliveryStreamElasticsearchConfigurationProcessingConfigurationOutputReference;
+    putProcessingConfiguration(value: KinesisFirehoseDeliveryStreamElasticsearchConfigurationProcessingConfiguration): void;
+    resetProcessingConfiguration(): void;
+    get processingConfigurationInput(): KinesisFirehoseDeliveryStreamElasticsearchConfigurationProcessingConfiguration | undefined;
+    private _s3Configuration;
+    get s3Configuration(): KinesisFirehoseDeliveryStreamElasticsearchConfigurationS3ConfigurationOutputReference;
+    putS3Configuration(value: KinesisFirehoseDeliveryStreamElasticsearchConfigurationS3Configuration): void;
+    get s3ConfigurationInput(): KinesisFirehoseDeliveryStreamElasticsearchConfigurationS3Configuration | undefined;
+    private _vpcConfig;
+    get vpcConfig(): KinesisFirehoseDeliveryStreamElasticsearchConfigurationVpcConfigOutputReference;
+    putVpcConfig(value: KinesisFirehoseDeliveryStreamElasticsearchConfigurationVpcConfig): void;
+    resetVpcConfig(): void;
+    get vpcConfigInput(): KinesisFirehoseDeliveryStreamElasticsearchConfigurationVpcConfig | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamExtendedS3ConfigurationCloudwatchLoggingOptions {
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#enabled KinesisFirehoseDeliveryStream#enabled}
+    */
+    readonly enabled?: boolean | cdktf.IResolvable;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#log_group_name KinesisFirehoseDeliveryStream#log_group_name}
+    */
+    readonly logGroupName?: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#log_stream_name KinesisFirehoseDeliveryStream#log_stream_name}
+    */
+    readonly logStreamName?: string;
+}
+export declare function kinesisFirehoseDeliveryStreamExtendedS3ConfigurationCloudwatchLoggingOptionsToTerraform(struct?: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationCloudwatchLoggingOptionsOutputReference | KinesisFirehoseDeliveryStreamExtendedS3ConfigurationCloudwatchLoggingOptions): any;
+export declare function kinesisFirehoseDeliveryStreamExtendedS3ConfigurationCloudwatchLoggingOptionsToHclTerraform(struct?: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationCloudwatchLoggingOptionsOutputReference | KinesisFirehoseDeliveryStreamExtendedS3ConfigurationCloudwatchLoggingOptions): any;
+export declare class KinesisFirehoseDeliveryStreamExtendedS3ConfigurationCloudwatchLoggingOptionsOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamExtendedS3ConfigurationCloudwatchLoggingOptions | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationCloudwatchLoggingOptions | undefined);
+    private _enabled?;
+    get enabled(): boolean | cdktf.IResolvable;
+    set enabled(value: boolean | cdktf.IResolvable);
+    resetEnabled(): void;
+    get enabledInput(): boolean | cdktf.IResolvable | undefined;
+    private _logGroupName?;
+    get logGroupName(): string;
+    set logGroupName(value: string);
+    resetLogGroupName(): void;
+    get logGroupNameInput(): string | undefined;
+    private _logStreamName?;
+    get logStreamName(): string;
+    set logStreamName(value: string);
+    resetLogStreamName(): void;
+    get logStreamNameInput(): string | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationInputFormatConfigurationDeserializerHiveJsonSerDe {
+    /** (Optional) A list of how you want Kinesis Data Firehose to parse the date and time stamps that may be present in your input data JSON. To specify these format strings, follow the pattern syntax of JodaTime's DateTimeFormat format strings. For more information, see [Class DateTimeFormat](https://www.joda.org/joda-time/apidocs/org/joda/time/format/DateTimeFormat.html). You can also use the special value millis to parse time stamps in epoch milliseconds. If you don't specify a format, Kinesis Data Firehose uses java.sql.Timestamp::valueOf by default. */
+    readonly timestampFormats?: string[];
+}
+export declare function kinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationInputFormatConfigurationDeserializerHiveJsonSerDeToTerraform(struct?: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationInputFormatConfigurationDeserializerHiveJsonSerDeOutputReference | KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationInputFormatConfigurationDeserializerHiveJsonSerDe): any;
+export declare function kinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationInputFormatConfigurationDeserializerHiveJsonSerDeToHclTerraform(struct?: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationInputFormatConfigurationDeserializerHiveJsonSerDeOutputReference | KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationInputFormatConfigurationDeserializerHiveJsonSerDe): any;
+export declare class KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationInputFormatConfigurationDeserializerHiveJsonSerDeOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationInputFormatConfigurationDeserializerHiveJsonSerDe | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationInputFormatConfigurationDeserializerHiveJsonSerDe | undefined);
+    private _timestampFormats?;
+    get timestampFormats(): string[];
+    set timestampFormats(value: string[]);
+    resetTimestampFormats(): void;
+    get timestampFormatsInput(): string[] | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationInputFormatConfigurationDeserializerOpenXJsonSerDe {
+    /** (Optional) When set to true, which is the default, Kinesis Data Firehose converts JSON keys to lowercase before deserializing them. */
+    readonly caseInsensitive?: boolean | cdktf.IResolvable;
+    /** (Optional) A map of column names to JSON keys that aren't identical to the column names. This is useful when the JSON contains keys that are Hive keywords. For example, timestamp is a Hive keyword. If you have a JSON key named timestamp, set this parameter to `{ ts = "timestamp" }` to map this key to a column named ts. */
+    readonly columnToJsonKeyMappings?: {
+        [key: string]: string;
+    };
+    /** (Optional) When set to `true`, specifies that the names of the keys include dots and that you want Kinesis Data Firehose to replace them with underscores. This is useful because Apache Hive does not allow dots in column names. For example, if the JSON contains a key whose name is "a.b", you can define the column name to be "a_b" when using this option. Defaults to `false`. */
+    readonly convertDotsInJsonKeysToUnderscores?: boolean | cdktf.IResolvable;
+}
+export declare function kinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationInputFormatConfigurationDeserializerOpenXJsonSerDeToTerraform(struct?: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationInputFormatConfigurationDeserializerOpenXJsonSerDeOutputReference | KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationInputFormatConfigurationDeserializerOpenXJsonSerDe): any;
+export declare function kinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationInputFormatConfigurationDeserializerOpenXJsonSerDeToHclTerraform(struct?: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationInputFormatConfigurationDeserializerOpenXJsonSerDeOutputReference | KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationInputFormatConfigurationDeserializerOpenXJsonSerDe): any;
+export declare class KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationInputFormatConfigurationDeserializerOpenXJsonSerDeOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationInputFormatConfigurationDeserializerOpenXJsonSerDe | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationInputFormatConfigurationDeserializerOpenXJsonSerDe | undefined);
+    private _caseInsensitive?;
+    get caseInsensitive(): boolean | cdktf.IResolvable;
+    set caseInsensitive(value: boolean | cdktf.IResolvable);
+    resetCaseInsensitive(): void;
+    get caseInsensitiveInput(): boolean | cdktf.IResolvable | undefined;
+    private _columnToJsonKeyMappings?;
+    get columnToJsonKeyMappings(): {
+        [key: string]: string;
+    };
+    set columnToJsonKeyMappings(value: {
+        [key: string]: string;
+    });
+    resetColumnToJsonKeyMappings(): void;
+    get columnToJsonKeyMappingsInput(): {
+        [key: string]: string;
+    } | undefined;
+    private _convertDotsInJsonKeysToUnderscores?;
+    get convertDotsInJsonKeysToUnderscores(): boolean | cdktf.IResolvable;
+    set convertDotsInJsonKeysToUnderscores(value: boolean | cdktf.IResolvable);
+    resetConvertDotsInJsonKeysToUnderscores(): void;
+    get convertDotsInJsonKeysToUnderscoresInput(): boolean | cdktf.IResolvable | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationInputFormatConfigurationDeserializer {
+    /** */
+    readonly hiveJsonSerDe?: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationInputFormatConfigurationDeserializerHiveJsonSerDe;
+    /** */
+    readonly openXJsonSerDe?: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationInputFormatConfigurationDeserializerOpenXJsonSerDe;
+}
+export declare function kinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationInputFormatConfigurationDeserializerToTerraform(struct?: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationInputFormatConfigurationDeserializerOutputReference | KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationInputFormatConfigurationDeserializer): any;
+export declare function kinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationInputFormatConfigurationDeserializerToHclTerraform(struct?: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationInputFormatConfigurationDeserializerOutputReference | KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationInputFormatConfigurationDeserializer): any;
+export declare class KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationInputFormatConfigurationDeserializerOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationInputFormatConfigurationDeserializer | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationInputFormatConfigurationDeserializer | undefined);
+    private _hiveJsonSerDe;
+    get hiveJsonSerDe(): KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationInputFormatConfigurationDeserializerHiveJsonSerDeOutputReference;
+    putHiveJsonSerDe(value: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationInputFormatConfigurationDeserializerHiveJsonSerDe): void;
+    resetHiveJsonSerDe(): void;
+    get hiveJsonSerDeInput(): KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationInputFormatConfigurationDeserializerHiveJsonSerDe | undefined;
+    private _openXJsonSerDe;
+    get openXJsonSerDe(): KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationInputFormatConfigurationDeserializerOpenXJsonSerDeOutputReference;
+    putOpenXJsonSerDe(value: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationInputFormatConfigurationDeserializerOpenXJsonSerDe): void;
+    resetOpenXJsonSerDe(): void;
+    get openXJsonSerDeInput(): KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationInputFormatConfigurationDeserializerOpenXJsonSerDe | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationInputFormatConfiguration {
+    /** */
+    readonly deserializer: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationInputFormatConfigurationDeserializer;
+}
+export declare function kinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationInputFormatConfigurationToTerraform(struct?: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationInputFormatConfigurationOutputReference | KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationInputFormatConfiguration): any;
+export declare function kinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationInputFormatConfigurationToHclTerraform(struct?: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationInputFormatConfigurationOutputReference | KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationInputFormatConfiguration): any;
+export declare class KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationInputFormatConfigurationOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationInputFormatConfiguration | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationInputFormatConfiguration | undefined);
+    private _deserializer;
+    get deserializer(): KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationInputFormatConfigurationDeserializerOutputReference;
+    putDeserializer(value: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationInputFormatConfigurationDeserializer): void;
+    get deserializerInput(): KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationInputFormatConfigurationDeserializer | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationOutputFormatConfigurationSerializerOrcSerDe {
+    /** (Optional) The Hadoop Distributed File System (HDFS) block size. This is useful if you intend to copy the data from Amazon S3 to HDFS before querying. The default is 256 MiB and the minimum is 64 MiB. Kinesis Data Firehose uses this value for padding calculations. */
+    readonly blockSizeBytes?: number;
+    /** (Optional) A list of column names for which you want Kinesis Data Firehose to create bloom filters. */
+    readonly bloomFilterColumns?: string[];
+    /** (Optional) The Bloom filter false positive probability (FPP). The lower the FPP, the bigger the Bloom filter. The default value is `0.05`, the minimum is `0`, and the maximum is `1`. */
+    readonly bloomFilterFalsePositiveProbability?: number;
+    /** (Optional) The compression code to use over data blocks. The default is `SNAPPY`. */
+    readonly compression?: string;
+    /** (Optional) A float that represents the fraction of the total number of non-null rows. To turn off dictionary encoding, set this fraction to a number that is less than the number of distinct keys in a dictionary. To always use dictionary encoding, set this threshold to `1`. */
+    readonly dictionaryKeyThreshold?: number;
+    /** (Optional) Set this to `true` to indicate that you want stripes to be padded to the HDFS block boundaries. This is useful if you intend to copy the data from Amazon S3 to HDFS before querying. The default is `false`. */
+    readonly enablePadding?: boolean | cdktf.IResolvable;
+    /** (Optional) The version of the file to write. The possible values are `V0_11` and `V0_12`. The default is `V0_12`. */
+    readonly formatVersion?: string;
+    /** (Optional) A float between 0 and 1 that defines the tolerance for block padding as a decimal fraction of stripe size. The default value is `0.05`, which means 5 percent of stripe size. For the default values of 64 MiB ORC stripes and 256 MiB HDFS blocks, the default block padding tolerance of 5 percent reserves a maximum of 3.2 MiB for padding within the 256 MiB block. In such a case, if the available size within the block is more than 3.2 MiB, a new, smaller stripe is inserted to fit within that space. This ensures that no stripe crosses block boundaries and causes remote reads within a node-local task. Kinesis Data Firehose ignores this parameter when `enablePadding` is `false`. */
+    readonly paddingTolerance?: number;
+    /** (Optional) The number of rows between index entries. The default is `10000` and the minimum is `1000`. */
+    readonly rowIndexStride?: number;
+    /** (Optional) The number of bytes in each stripe. The default is 64 MiB and the minimum is 8 MiB. */
+    readonly stripeSizeBytes?: number;
+}
+export declare function kinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationOutputFormatConfigurationSerializerOrcSerDeToTerraform(struct?: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationOutputFormatConfigurationSerializerOrcSerDeOutputReference | KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationOutputFormatConfigurationSerializerOrcSerDe): any;
+export declare function kinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationOutputFormatConfigurationSerializerOrcSerDeToHclTerraform(struct?: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationOutputFormatConfigurationSerializerOrcSerDeOutputReference | KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationOutputFormatConfigurationSerializerOrcSerDe): any;
+export declare class KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationOutputFormatConfigurationSerializerOrcSerDeOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationOutputFormatConfigurationSerializerOrcSerDe | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationOutputFormatConfigurationSerializerOrcSerDe | undefined);
+    private _blockSizeBytes?;
+    get blockSizeBytes(): number;
+    set blockSizeBytes(value: number);
+    resetBlockSizeBytes(): void;
+    get blockSizeBytesInput(): number | undefined;
+    private _bloomFilterColumns?;
+    get bloomFilterColumns(): string[];
+    set bloomFilterColumns(value: string[]);
+    resetBloomFilterColumns(): void;
+    get bloomFilterColumnsInput(): string[] | undefined;
+    private _bloomFilterFalsePositiveProbability?;
+    get bloomFilterFalsePositiveProbability(): number;
+    set bloomFilterFalsePositiveProbability(value: number);
+    resetBloomFilterFalsePositiveProbability(): void;
+    get bloomFilterFalsePositiveProbabilityInput(): number | undefined;
+    private _compression?;
+    get compression(): string;
+    set compression(value: string);
+    resetCompression(): void;
+    get compressionInput(): string | undefined;
+    private _dictionaryKeyThreshold?;
+    get dictionaryKeyThreshold(): number;
+    set dictionaryKeyThreshold(value: number);
+    resetDictionaryKeyThreshold(): void;
+    get dictionaryKeyThresholdInput(): number | undefined;
+    private _enablePadding?;
+    get enablePadding(): boolean | cdktf.IResolvable;
+    set enablePadding(value: boolean | cdktf.IResolvable);
+    resetEnablePadding(): void;
+    get enablePaddingInput(): boolean | cdktf.IResolvable | undefined;
+    private _formatVersion?;
+    get formatVersion(): string;
+    set formatVersion(value: string);
+    resetFormatVersion(): void;
+    get formatVersionInput(): string | undefined;
+    private _paddingTolerance?;
+    get paddingTolerance(): number;
+    set paddingTolerance(value: number);
+    resetPaddingTolerance(): void;
+    get paddingToleranceInput(): number | undefined;
+    private _rowIndexStride?;
+    get rowIndexStride(): number;
+    set rowIndexStride(value: number);
+    resetRowIndexStride(): void;
+    get rowIndexStrideInput(): number | undefined;
+    private _stripeSizeBytes?;
+    get stripeSizeBytes(): number;
+    set stripeSizeBytes(value: number);
+    resetStripeSizeBytes(): void;
+    get stripeSizeBytesInput(): number | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationOutputFormatConfigurationSerializerParquetSerDe {
+    /** (Optional) The Hadoop Distributed File System (HDFS) block size. This is useful if you intend to copy the data from Amazon S3 to HDFS before querying. The default is 256 MiB and the minimum is 64 MiB. Kinesis Data Firehose uses this value for padding calculations. */
+    readonly blockSizeBytes?: number;
+    /** (Optional) The compression code to use over data blocks. The possible values are `UNCOMPRESSED`, `SNAPPY`, and `GZIP`, with the default being `SNAPPY`. Use `SNAPPY` for higher decompression speed. Use `GZIP` if the compression ratio is more important than speed. */
+    readonly compression?: string;
+    /** (Optional) Indicates whether to enable dictionary compression. */
+    readonly enableDictionaryCompression?: boolean | cdktf.IResolvable;
+    /** (Optional) The maximum amount of padding to apply. This is useful if you intend to copy the data from Amazon S3 to HDFS before querying. The default is `0`. */
+    readonly maxPaddingBytes?: number;
+    /** (Optional) The Parquet page size. Column chunks are divided into pages. A page is conceptually an indivisible unit (in terms of compression and encoding). The minimum value is 64 KiB and the default is 1 MiB. */
+    readonly pageSizeBytes?: number;
+    /** (Optional) Indicates the version of row format to output. The possible values are `V1` and `V2`. The default is `V1`. */
+    readonly writerVersion?: string;
+}
+export declare function kinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationOutputFormatConfigurationSerializerParquetSerDeToTerraform(struct?: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationOutputFormatConfigurationSerializerParquetSerDeOutputReference | KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationOutputFormatConfigurationSerializerParquetSerDe): any;
+export declare function kinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationOutputFormatConfigurationSerializerParquetSerDeToHclTerraform(struct?: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationOutputFormatConfigurationSerializerParquetSerDeOutputReference | KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationOutputFormatConfigurationSerializerParquetSerDe): any;
+export declare class KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationOutputFormatConfigurationSerializerParquetSerDeOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationOutputFormatConfigurationSerializerParquetSerDe | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationOutputFormatConfigurationSerializerParquetSerDe | undefined);
+    private _blockSizeBytes?;
+    get blockSizeBytes(): number;
+    set blockSizeBytes(value: number);
+    resetBlockSizeBytes(): void;
+    get blockSizeBytesInput(): number | undefined;
+    private _compression?;
+    get compression(): string;
+    set compression(value: string);
+    resetCompression(): void;
+    get compressionInput(): string | undefined;
+    private _enableDictionaryCompression?;
+    get enableDictionaryCompression(): boolean | cdktf.IResolvable;
+    set enableDictionaryCompression(value: boolean | cdktf.IResolvable);
+    resetEnableDictionaryCompression(): void;
+    get enableDictionaryCompressionInput(): boolean | cdktf.IResolvable | undefined;
+    private _maxPaddingBytes?;
+    get maxPaddingBytes(): number;
+    set maxPaddingBytes(value: number);
+    resetMaxPaddingBytes(): void;
+    get maxPaddingBytesInput(): number | undefined;
+    private _pageSizeBytes?;
+    get pageSizeBytes(): number;
+    set pageSizeBytes(value: number);
+    resetPageSizeBytes(): void;
+    get pageSizeBytesInput(): number | undefined;
+    private _writerVersion?;
+    get writerVersion(): string;
+    set writerVersion(value: string);
+    resetWriterVersion(): void;
+    get writerVersionInput(): string | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationOutputFormatConfigurationSerializer {
+    /** */
+    readonly orcSerDe?: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationOutputFormatConfigurationSerializerOrcSerDe;
+    /** */
+    readonly parquetSerDe?: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationOutputFormatConfigurationSerializerParquetSerDe;
+}
+export declare function kinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationOutputFormatConfigurationSerializerToTerraform(struct?: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationOutputFormatConfigurationSerializerOutputReference | KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationOutputFormatConfigurationSerializer): any;
+export declare function kinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationOutputFormatConfigurationSerializerToHclTerraform(struct?: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationOutputFormatConfigurationSerializerOutputReference | KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationOutputFormatConfigurationSerializer): any;
+export declare class KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationOutputFormatConfigurationSerializerOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationOutputFormatConfigurationSerializer | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationOutputFormatConfigurationSerializer | undefined);
+    private _orcSerDe;
+    get orcSerDe(): KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationOutputFormatConfigurationSerializerOrcSerDeOutputReference;
+    putOrcSerDe(value: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationOutputFormatConfigurationSerializerOrcSerDe): void;
+    resetOrcSerDe(): void;
+    get orcSerDeInput(): KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationOutputFormatConfigurationSerializerOrcSerDe | undefined;
+    private _parquetSerDe;
+    get parquetSerDe(): KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationOutputFormatConfigurationSerializerParquetSerDeOutputReference;
+    putParquetSerDe(value: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationOutputFormatConfigurationSerializerParquetSerDe): void;
+    resetParquetSerDe(): void;
+    get parquetSerDeInput(): KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationOutputFormatConfigurationSerializerParquetSerDe | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationOutputFormatConfiguration {
+    /** */
+    readonly serializer: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationOutputFormatConfigurationSerializer;
+}
+export declare function kinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationOutputFormatConfigurationToTerraform(struct?: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationOutputFormatConfigurationOutputReference | KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationOutputFormatConfiguration): any;
+export declare function kinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationOutputFormatConfigurationToHclTerraform(struct?: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationOutputFormatConfigurationOutputReference | KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationOutputFormatConfiguration): any;
+export declare class KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationOutputFormatConfigurationOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationOutputFormatConfiguration | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationOutputFormatConfiguration | undefined);
+    private _serializer;
+    get serializer(): KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationOutputFormatConfigurationSerializerOutputReference;
+    putSerializer(value: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationOutputFormatConfigurationSerializer): void;
+    get serializerInput(): KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationOutputFormatConfigurationSerializer | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationSchemaConfiguration {
+    /** (Optional) The ID of the AWS Glue Data Catalog. If you don't supply this, the AWS account ID is used by default. */
+    readonly catalogId?: string;
+    /** (Required) Specifies the name of the AWS Glue database that contains the schema for the output data. */
+    readonly databaseName: string;
+    /** (Optional) If you don't specify an AWS Region, the default is the current region. */
+    readonly region?: string;
+    /** (Required) The role that Kinesis Data Firehose can use to access AWS Glue. This role must be in the same account you use for Kinesis Data Firehose. Cross-account roles aren't allowed. */
+    readonly roleArn: string;
+    /** (Required) Specifies the AWS Glue table that contains the column information that constitutes your data schema. */
+    readonly tableName: string;
+    /** (Optional) Specifies the table version for the output data schema. Defaults to `LATEST`. */
+    readonly versionId?: string;
+}
+export declare function kinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationSchemaConfigurationToTerraform(struct?: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationSchemaConfigurationOutputReference | KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationSchemaConfiguration): any;
+export declare function kinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationSchemaConfigurationToHclTerraform(struct?: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationSchemaConfigurationOutputReference | KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationSchemaConfiguration): any;
+export declare class KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationSchemaConfigurationOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationSchemaConfiguration | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationSchemaConfiguration | undefined);
+    private _catalogId?;
+    get catalogId(): string;
+    set catalogId(value: string);
+    resetCatalogId(): void;
+    get catalogIdInput(): string | undefined;
+    private _databaseName?;
+    get databaseName(): string;
+    set databaseName(value: string);
+    get databaseNameInput(): string | undefined;
+    private _region?;
+    get region(): string;
+    set region(value: string);
+    resetRegion(): void;
+    get regionInput(): string | undefined;
+    private _roleArn?;
+    get roleArn(): string;
+    set roleArn(value: string);
+    get roleArnInput(): string | undefined;
+    private _tableName?;
+    get tableName(): string;
+    set tableName(value: string);
+    get tableNameInput(): string | undefined;
+    private _versionId?;
+    get versionId(): string;
+    set versionId(value: string);
+    resetVersionId(): void;
+    get versionIdInput(): string | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfiguration {
+    /** (Optional) Defaults to `true`. Set it to `false` if you want to disable format conversion while preserving the configuration details. */
+    readonly enabled?: boolean | cdktf.IResolvable;
+    /** */
+    readonly inputFormatConfiguration: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationInputFormatConfiguration;
+    /** */
+    readonly outputFormatConfiguration: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationOutputFormatConfiguration;
+    /** */
+    readonly schemaConfiguration: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationSchemaConfiguration;
+}
+export declare function kinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationToTerraform(struct?: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationOutputReference | KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfiguration): any;
+export declare function kinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationToHclTerraform(struct?: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationOutputReference | KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfiguration): any;
+export declare class KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfiguration | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfiguration | undefined);
+    private _enabled?;
+    get enabled(): boolean | cdktf.IResolvable;
+    set enabled(value: boolean | cdktf.IResolvable);
+    resetEnabled(): void;
+    get enabledInput(): boolean | cdktf.IResolvable | undefined;
+    private _inputFormatConfiguration;
+    get inputFormatConfiguration(): KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationInputFormatConfigurationOutputReference;
+    putInputFormatConfiguration(value: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationInputFormatConfiguration): void;
+    get inputFormatConfigurationInput(): KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationInputFormatConfiguration | undefined;
+    private _outputFormatConfiguration;
+    get outputFormatConfiguration(): KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationOutputFormatConfigurationOutputReference;
+    putOutputFormatConfiguration(value: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationOutputFormatConfiguration): void;
+    get outputFormatConfigurationInput(): KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationOutputFormatConfiguration | undefined;
+    private _schemaConfiguration;
+    get schemaConfiguration(): KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationSchemaConfigurationOutputReference;
+    putSchemaConfiguration(value: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationSchemaConfiguration): void;
+    get schemaConfigurationInput(): KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationSchemaConfiguration | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDynamicPartitioningConfiguration {
+    /** (Optional) Enables or disables dynamic partitioning. Defaults to `false`. **NOTE:** You can enable dynamic partitioning only when you create a new delivery stream. Once you enable dynamic partitioning on a delivery stream, it cannot be disabled on this delivery stream. Therefore, Terraform will recreate the resource whenever dynamic partitioning is enabled or disabled. */
+    readonly enabled?: boolean | cdktf.IResolvable;
+    /** (Optional) Total amount of seconds Firehose spends on retries. Valid values between 0 and 7200. Default is 300. */
+    readonly retryDuration?: number;
+}
+export declare function kinesisFirehoseDeliveryStreamExtendedS3ConfigurationDynamicPartitioningConfigurationToTerraform(struct?: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDynamicPartitioningConfigurationOutputReference | KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDynamicPartitioningConfiguration): any;
+export declare function kinesisFirehoseDeliveryStreamExtendedS3ConfigurationDynamicPartitioningConfigurationToHclTerraform(struct?: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDynamicPartitioningConfigurationOutputReference | KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDynamicPartitioningConfiguration): any;
+export declare class KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDynamicPartitioningConfigurationOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDynamicPartitioningConfiguration | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDynamicPartitioningConfiguration | undefined);
+    private _enabled?;
+    get enabled(): boolean | cdktf.IResolvable;
+    set enabled(value: boolean | cdktf.IResolvable);
+    resetEnabled(): void;
+    get enabledInput(): boolean | cdktf.IResolvable | undefined;
+    private _retryDuration?;
+    get retryDuration(): number;
+    set retryDuration(value: number);
+    resetRetryDuration(): void;
+    get retryDurationInput(): number | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamExtendedS3ConfigurationProcessingConfigurationProcessorsParameters {
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#parameter_name KinesisFirehoseDeliveryStream#parameter_name}
+    */
+    readonly parameterName: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#parameter_value KinesisFirehoseDeliveryStream#parameter_value}
+    */
+    readonly parameterValue: string;
+}
+export declare function kinesisFirehoseDeliveryStreamExtendedS3ConfigurationProcessingConfigurationProcessorsParametersToTerraform(struct?: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationProcessingConfigurationProcessorsParameters | cdktf.IResolvable): any;
+export declare function kinesisFirehoseDeliveryStreamExtendedS3ConfigurationProcessingConfigurationProcessorsParametersToHclTerraform(struct?: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationProcessingConfigurationProcessorsParameters | cdktf.IResolvable): any;
+export declare class KinesisFirehoseDeliveryStreamExtendedS3ConfigurationProcessingConfigurationProcessorsParametersOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    private resolvableValue?;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    * @param complexObjectIndex the index of this item in the list
+    * @param complexObjectIsFromSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string, complexObjectIndex: number, complexObjectIsFromSet: boolean);
+    get internalValue(): KinesisFirehoseDeliveryStreamExtendedS3ConfigurationProcessingConfigurationProcessorsParameters | cdktf.IResolvable | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationProcessingConfigurationProcessorsParameters | cdktf.IResolvable | undefined);
+    private _parameterName?;
+    get parameterName(): string;
+    set parameterName(value: string);
+    get parameterNameInput(): string | undefined;
+    private _parameterValue?;
+    get parameterValue(): string;
+    set parameterValue(value: string);
+    get parameterValueInput(): string | undefined;
+}
+export declare class KinesisFirehoseDeliveryStreamExtendedS3ConfigurationProcessingConfigurationProcessorsParametersList extends cdktf.ComplexList {
+    protected terraformResource: cdktf.IInterpolatingParent;
+    protected terraformAttribute: string;
+    protected wrapsSet: boolean;
+    internalValue?: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationProcessingConfigurationProcessorsParameters[] | cdktf.IResolvable;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    * @param wrapsSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string, wrapsSet: boolean);
+    /**
+    * @param index the index of the item to return
+    */
+    get(index: number): KinesisFirehoseDeliveryStreamExtendedS3ConfigurationProcessingConfigurationProcessorsParametersOutputReference;
+}
+export interface KinesisFirehoseDeliveryStreamExtendedS3ConfigurationProcessingConfigurationProcessors {
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#type KinesisFirehoseDeliveryStream#type}
+    */
+    readonly type: string;
+    /**
+    * parameters block
+    *
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#parameters KinesisFirehoseDeliveryStream#parameters}
+    */
+    readonly parameters?: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationProcessingConfigurationProcessorsParameters[] | cdktf.IResolvable;
+}
+export declare function kinesisFirehoseDeliveryStreamExtendedS3ConfigurationProcessingConfigurationProcessorsToTerraform(struct?: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationProcessingConfigurationProcessors | cdktf.IResolvable): any;
+export declare function kinesisFirehoseDeliveryStreamExtendedS3ConfigurationProcessingConfigurationProcessorsToHclTerraform(struct?: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationProcessingConfigurationProcessors | cdktf.IResolvable): any;
+export declare class KinesisFirehoseDeliveryStreamExtendedS3ConfigurationProcessingConfigurationProcessorsOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    private resolvableValue?;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    * @param complexObjectIndex the index of this item in the list
+    * @param complexObjectIsFromSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string, complexObjectIndex: number, complexObjectIsFromSet: boolean);
+    get internalValue(): KinesisFirehoseDeliveryStreamExtendedS3ConfigurationProcessingConfigurationProcessors | cdktf.IResolvable | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationProcessingConfigurationProcessors | cdktf.IResolvable | undefined);
+    private _type?;
+    get type(): string;
+    set type(value: string);
+    get typeInput(): string | undefined;
+    private _parameters;
+    get parameters(): KinesisFirehoseDeliveryStreamExtendedS3ConfigurationProcessingConfigurationProcessorsParametersList;
+    putParameters(value: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationProcessingConfigurationProcessorsParameters[] | cdktf.IResolvable): void;
+    resetParameters(): void;
+    get parametersInput(): cdktf.IResolvable | KinesisFirehoseDeliveryStreamExtendedS3ConfigurationProcessingConfigurationProcessorsParameters[] | undefined;
+}
+export declare class KinesisFirehoseDeliveryStreamExtendedS3ConfigurationProcessingConfigurationProcessorsList extends cdktf.ComplexList {
+    protected terraformResource: cdktf.IInterpolatingParent;
+    protected terraformAttribute: string;
+    protected wrapsSet: boolean;
+    internalValue?: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationProcessingConfigurationProcessors[] | cdktf.IResolvable;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    * @param wrapsSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string, wrapsSet: boolean);
+    /**
+    * @param index the index of the item to return
+    */
+    get(index: number): KinesisFirehoseDeliveryStreamExtendedS3ConfigurationProcessingConfigurationProcessorsOutputReference;
+}
+export interface KinesisFirehoseDeliveryStreamExtendedS3ConfigurationProcessingConfiguration {
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#enabled KinesisFirehoseDeliveryStream#enabled}
+    */
+    readonly enabled?: boolean | cdktf.IResolvable;
+    /**
+    * processors block
+    *
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#processors KinesisFirehoseDeliveryStream#processors}
+    */
+    readonly processors?: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationProcessingConfigurationProcessors[] | cdktf.IResolvable;
+}
+export declare function kinesisFirehoseDeliveryStreamExtendedS3ConfigurationProcessingConfigurationToTerraform(struct?: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationProcessingConfigurationOutputReference | KinesisFirehoseDeliveryStreamExtendedS3ConfigurationProcessingConfiguration): any;
+export declare function kinesisFirehoseDeliveryStreamExtendedS3ConfigurationProcessingConfigurationToHclTerraform(struct?: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationProcessingConfigurationOutputReference | KinesisFirehoseDeliveryStreamExtendedS3ConfigurationProcessingConfiguration): any;
+export declare class KinesisFirehoseDeliveryStreamExtendedS3ConfigurationProcessingConfigurationOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamExtendedS3ConfigurationProcessingConfiguration | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationProcessingConfiguration | undefined);
+    private _enabled?;
+    get enabled(): boolean | cdktf.IResolvable;
+    set enabled(value: boolean | cdktf.IResolvable);
+    resetEnabled(): void;
+    get enabledInput(): boolean | cdktf.IResolvable | undefined;
+    private _processors;
+    get processors(): KinesisFirehoseDeliveryStreamExtendedS3ConfigurationProcessingConfigurationProcessorsList;
+    putProcessors(value: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationProcessingConfigurationProcessors[] | cdktf.IResolvable): void;
+    resetProcessors(): void;
+    get processorsInput(): cdktf.IResolvable | KinesisFirehoseDeliveryStreamExtendedS3ConfigurationProcessingConfigurationProcessors[] | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamExtendedS3ConfigurationS3BackupConfigurationCloudwatchLoggingOptions {
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#enabled KinesisFirehoseDeliveryStream#enabled}
+    */
+    readonly enabled?: boolean | cdktf.IResolvable;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#log_group_name KinesisFirehoseDeliveryStream#log_group_name}
+    */
+    readonly logGroupName?: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#log_stream_name KinesisFirehoseDeliveryStream#log_stream_name}
+    */
+    readonly logStreamName?: string;
+}
+export declare function kinesisFirehoseDeliveryStreamExtendedS3ConfigurationS3BackupConfigurationCloudwatchLoggingOptionsToTerraform(struct?: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationS3BackupConfigurationCloudwatchLoggingOptionsOutputReference | KinesisFirehoseDeliveryStreamExtendedS3ConfigurationS3BackupConfigurationCloudwatchLoggingOptions): any;
+export declare function kinesisFirehoseDeliveryStreamExtendedS3ConfigurationS3BackupConfigurationCloudwatchLoggingOptionsToHclTerraform(struct?: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationS3BackupConfigurationCloudwatchLoggingOptionsOutputReference | KinesisFirehoseDeliveryStreamExtendedS3ConfigurationS3BackupConfigurationCloudwatchLoggingOptions): any;
+export declare class KinesisFirehoseDeliveryStreamExtendedS3ConfigurationS3BackupConfigurationCloudwatchLoggingOptionsOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamExtendedS3ConfigurationS3BackupConfigurationCloudwatchLoggingOptions | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationS3BackupConfigurationCloudwatchLoggingOptions | undefined);
+    private _enabled?;
+    get enabled(): boolean | cdktf.IResolvable;
+    set enabled(value: boolean | cdktf.IResolvable);
+    resetEnabled(): void;
+    get enabledInput(): boolean | cdktf.IResolvable | undefined;
+    private _logGroupName?;
+    get logGroupName(): string;
+    set logGroupName(value: string);
+    resetLogGroupName(): void;
+    get logGroupNameInput(): string | undefined;
+    private _logStreamName?;
+    get logStreamName(): string;
+    set logStreamName(value: string);
+    resetLogStreamName(): void;
+    get logStreamNameInput(): string | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamExtendedS3ConfigurationS3BackupConfiguration {
+    /** (Required) The ARN of the S3 bucket */
+    readonly bucketArn: string;
+    /** (Optional) Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. The default value is 300. */
+    readonly bufferingInterval?: number;
+    /** (Optional) Buffer incoming data to the specified size, in MBs, before delivering it to the destination. The default value is 5. */
+    readonly bufferingSize?: number;
+    /** (Optional) The compression format. If no value is specified, the default is `UNCOMPRESSED`. Other supported values are `GZIP`, `ZIP`, `Snappy`, & `HADOOP_SNAPPY`. */
+    readonly compressionFormat?: string;
+    /** (Optional) Prefix added to failed records before writing them to S3. Not currently supported for `redshift` destination. This prefix appears immediately following the bucket name. For information about how to specify this prefix, see [Custom Prefixes for Amazon S3 Objects](https://docs.aws.amazon.com/firehose/latest/dev/s3-prefixes.html). */
+    readonly errorOutputPrefix?: string;
+    /** (Optional) Specifies the KMS key ARN the stream will use to encrypt data. If not set, no encryption will be used. */
+    readonly kmsKeyArn?: string;
+    /** (Optional) The "YYYY/MM/DD/HH" time format prefix is automatically used for delivered S3 files. You can specify an extra prefix to be added in front of the time format prefix. Note that if the prefix ends with a slash, it appears as a folder in the S3 bucket */
+    readonly prefix?: string;
+    /** (Required) The ARN of the AWS credentials. */
+    readonly roleArn: string;
+    /** */
+    readonly cloudwatchLoggingOptions?: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationS3BackupConfigurationCloudwatchLoggingOptions;
+}
+export declare function kinesisFirehoseDeliveryStreamExtendedS3ConfigurationS3BackupConfigurationToTerraform(struct?: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationS3BackupConfigurationOutputReference | KinesisFirehoseDeliveryStreamExtendedS3ConfigurationS3BackupConfiguration): any;
+export declare function kinesisFirehoseDeliveryStreamExtendedS3ConfigurationS3BackupConfigurationToHclTerraform(struct?: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationS3BackupConfigurationOutputReference | KinesisFirehoseDeliveryStreamExtendedS3ConfigurationS3BackupConfiguration): any;
+export declare class KinesisFirehoseDeliveryStreamExtendedS3ConfigurationS3BackupConfigurationOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamExtendedS3ConfigurationS3BackupConfiguration | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationS3BackupConfiguration | undefined);
+    private _bucketArn?;
+    get bucketArn(): string;
+    set bucketArn(value: string);
+    get bucketArnInput(): string | undefined;
+    private _bufferingInterval?;
+    get bufferingInterval(): number;
+    set bufferingInterval(value: number);
+    resetBufferingInterval(): void;
+    get bufferingIntervalInput(): number | undefined;
+    private _bufferingSize?;
+    get bufferingSize(): number;
+    set bufferingSize(value: number);
+    resetBufferingSize(): void;
+    get bufferingSizeInput(): number | undefined;
+    private _compressionFormat?;
+    get compressionFormat(): string;
+    set compressionFormat(value: string);
+    resetCompressionFormat(): void;
+    get compressionFormatInput(): string | undefined;
+    private _errorOutputPrefix?;
+    get errorOutputPrefix(): string;
+    set errorOutputPrefix(value: string);
+    resetErrorOutputPrefix(): void;
+    get errorOutputPrefixInput(): string | undefined;
+    private _kmsKeyArn?;
+    get kmsKeyArn(): string;
+    set kmsKeyArn(value: string);
+    resetKmsKeyArn(): void;
+    get kmsKeyArnInput(): string | undefined;
+    private _prefix?;
+    get prefix(): string;
+    set prefix(value: string);
+    resetPrefix(): void;
+    get prefixInput(): string | undefined;
+    private _roleArn?;
+    get roleArn(): string;
+    set roleArn(value: string);
+    get roleArnInput(): string | undefined;
+    private _cloudwatchLoggingOptions;
+    get cloudwatchLoggingOptions(): KinesisFirehoseDeliveryStreamExtendedS3ConfigurationS3BackupConfigurationCloudwatchLoggingOptionsOutputReference;
+    putCloudwatchLoggingOptions(value: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationS3BackupConfigurationCloudwatchLoggingOptions): void;
+    resetCloudwatchLoggingOptions(): void;
+    get cloudwatchLoggingOptionsInput(): KinesisFirehoseDeliveryStreamExtendedS3ConfigurationS3BackupConfigurationCloudwatchLoggingOptions | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamExtendedS3Configuration {
+    /** (Required) The ARN of the S3 bucket */
+    readonly bucketArn: string;
+    /** (Optional) Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. The default value is 300. */
+    readonly bufferingInterval?: number;
+    /** (Optional) Buffer incoming data to the specified size, in MBs, before delivering it to the destination. The default value is 5. */
+    readonly bufferingSize?: number;
+    /** (Optional) The compression format. If no value is specified, the default is `UNCOMPRESSED`. Other supported values are `GZIP`, `ZIP`, `Snappy`, & `HADOOP_SNAPPY`. */
+    readonly compressionFormat?: string;
+    /** (Optional) The time zone you prefer. Valid values are `UTC` or a non-3-letter IANA time zones (for example, `America/Los_Angeles`). Default value is `UTC`. */
+    readonly customTimeZone?: string;
+    /** (Optional) Prefix added to failed records before writing them to S3. Not currently supported for `redshift` destination. This prefix appears immediately following the bucket name. For information about how to specify this prefix, see [Custom Prefixes for Amazon S3 Objects](https://docs.aws.amazon.com/firehose/latest/dev/s3-prefixes.html). */
+    readonly errorOutputPrefix?: string;
+    /** (Optional) The file extension to override the default file extension (for example, `.json`). */
+    readonly fileExtension?: string;
+    /** (Optional) Specifies the KMS key ARN the stream will use to encrypt data. If not set, no encryption will be used. */
+    readonly kmsKeyArn?: string;
+    /** (Optional) The "YYYY/MM/DD/HH" time format prefix is automatically used for delivered S3 files. You can specify an extra prefix to be added in front of the time format prefix. Note that if the prefix ends with a slash, it appears as a folder in the S3 bucket */
+    readonly prefix?: string;
+    /** (Required) The ARN of the IAM role to be assumed by Firehose for calling the Amazon ES Configuration API and for indexing documents.  The IAM role must have permission for `DescribeElasticsearchDomain`, `DescribeElasticsearchDomains`, and `DescribeElasticsearchDomainConfig`.  The pattern needs to be `arn:.*`. */
+    readonly roleArn: string;
+    /** (Optional) Defines how documents should be delivered to Amazon S3.  Valid values are `FailedDocumentsOnly` and `AllDocuments`.  Default value is `FailedDocumentsOnly`. */
+    readonly s3BackupMode?: string;
+    /** */
+    readonly cloudwatchLoggingOptions?: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationCloudwatchLoggingOptions;
+    /** */
+    readonly dataFormatConversionConfiguration?: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfiguration;
+    /** */
+    readonly dynamicPartitioningConfiguration?: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDynamicPartitioningConfiguration;
+    /** */
+    readonly processingConfiguration?: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationProcessingConfiguration;
+    /** */
+    readonly s3BackupConfiguration?: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationS3BackupConfiguration;
+}
+export declare function kinesisFirehoseDeliveryStreamExtendedS3ConfigurationToTerraform(struct?: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationOutputReference | KinesisFirehoseDeliveryStreamExtendedS3Configuration): any;
+export declare function kinesisFirehoseDeliveryStreamExtendedS3ConfigurationToHclTerraform(struct?: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationOutputReference | KinesisFirehoseDeliveryStreamExtendedS3Configuration): any;
+export declare class KinesisFirehoseDeliveryStreamExtendedS3ConfigurationOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamExtendedS3Configuration | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamExtendedS3Configuration | undefined);
+    private _bucketArn?;
+    get bucketArn(): string;
+    set bucketArn(value: string);
+    get bucketArnInput(): string | undefined;
+    private _bufferingInterval?;
+    get bufferingInterval(): number;
+    set bufferingInterval(value: number);
+    resetBufferingInterval(): void;
+    get bufferingIntervalInput(): number | undefined;
+    private _bufferingSize?;
+    get bufferingSize(): number;
+    set bufferingSize(value: number);
+    resetBufferingSize(): void;
+    get bufferingSizeInput(): number | undefined;
+    private _compressionFormat?;
+    get compressionFormat(): string;
+    set compressionFormat(value: string);
+    resetCompressionFormat(): void;
+    get compressionFormatInput(): string | undefined;
+    private _customTimeZone?;
+    get customTimeZone(): string;
+    set customTimeZone(value: string);
+    resetCustomTimeZone(): void;
+    get customTimeZoneInput(): string | undefined;
+    private _errorOutputPrefix?;
+    get errorOutputPrefix(): string;
+    set errorOutputPrefix(value: string);
+    resetErrorOutputPrefix(): void;
+    get errorOutputPrefixInput(): string | undefined;
+    private _fileExtension?;
+    get fileExtension(): string;
+    set fileExtension(value: string);
+    resetFileExtension(): void;
+    get fileExtensionInput(): string | undefined;
+    private _kmsKeyArn?;
+    get kmsKeyArn(): string;
+    set kmsKeyArn(value: string);
+    resetKmsKeyArn(): void;
+    get kmsKeyArnInput(): string | undefined;
+    private _prefix?;
+    get prefix(): string;
+    set prefix(value: string);
+    resetPrefix(): void;
+    get prefixInput(): string | undefined;
+    private _roleArn?;
+    get roleArn(): string;
+    set roleArn(value: string);
+    get roleArnInput(): string | undefined;
+    private _s3BackupMode?;
+    get s3BackupMode(): string;
+    set s3BackupMode(value: string);
+    resetS3BackupMode(): void;
+    get s3BackupModeInput(): string | undefined;
+    private _cloudwatchLoggingOptions;
+    get cloudwatchLoggingOptions(): KinesisFirehoseDeliveryStreamExtendedS3ConfigurationCloudwatchLoggingOptionsOutputReference;
+    putCloudwatchLoggingOptions(value: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationCloudwatchLoggingOptions): void;
+    resetCloudwatchLoggingOptions(): void;
+    get cloudwatchLoggingOptionsInput(): KinesisFirehoseDeliveryStreamExtendedS3ConfigurationCloudwatchLoggingOptions | undefined;
+    private _dataFormatConversionConfiguration;
+    get dataFormatConversionConfiguration(): KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfigurationOutputReference;
+    putDataFormatConversionConfiguration(value: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfiguration): void;
+    resetDataFormatConversionConfiguration(): void;
+    get dataFormatConversionConfigurationInput(): KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDataFormatConversionConfiguration | undefined;
+    private _dynamicPartitioningConfiguration;
+    get dynamicPartitioningConfiguration(): KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDynamicPartitioningConfigurationOutputReference;
+    putDynamicPartitioningConfiguration(value: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDynamicPartitioningConfiguration): void;
+    resetDynamicPartitioningConfiguration(): void;
+    get dynamicPartitioningConfigurationInput(): KinesisFirehoseDeliveryStreamExtendedS3ConfigurationDynamicPartitioningConfiguration | undefined;
+    private _processingConfiguration;
+    get processingConfiguration(): KinesisFirehoseDeliveryStreamExtendedS3ConfigurationProcessingConfigurationOutputReference;
+    putProcessingConfiguration(value: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationProcessingConfiguration): void;
+    resetProcessingConfiguration(): void;
+    get processingConfigurationInput(): KinesisFirehoseDeliveryStreamExtendedS3ConfigurationProcessingConfiguration | undefined;
+    private _s3BackupConfiguration;
+    get s3BackupConfiguration(): KinesisFirehoseDeliveryStreamExtendedS3ConfigurationS3BackupConfigurationOutputReference;
+    putS3BackupConfiguration(value: KinesisFirehoseDeliveryStreamExtendedS3ConfigurationS3BackupConfiguration): void;
+    resetS3BackupConfiguration(): void;
+    get s3BackupConfigurationInput(): KinesisFirehoseDeliveryStreamExtendedS3ConfigurationS3BackupConfiguration | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamHttpEndpointConfigurationCloudwatchLoggingOptions {
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#enabled KinesisFirehoseDeliveryStream#enabled}
+    */
+    readonly enabled?: boolean | cdktf.IResolvable;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#log_group_name KinesisFirehoseDeliveryStream#log_group_name}
+    */
+    readonly logGroupName?: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#log_stream_name KinesisFirehoseDeliveryStream#log_stream_name}
+    */
+    readonly logStreamName?: string;
+}
+export declare function kinesisFirehoseDeliveryStreamHttpEndpointConfigurationCloudwatchLoggingOptionsToTerraform(struct?: KinesisFirehoseDeliveryStreamHttpEndpointConfigurationCloudwatchLoggingOptionsOutputReference | KinesisFirehoseDeliveryStreamHttpEndpointConfigurationCloudwatchLoggingOptions): any;
+export declare function kinesisFirehoseDeliveryStreamHttpEndpointConfigurationCloudwatchLoggingOptionsToHclTerraform(struct?: KinesisFirehoseDeliveryStreamHttpEndpointConfigurationCloudwatchLoggingOptionsOutputReference | KinesisFirehoseDeliveryStreamHttpEndpointConfigurationCloudwatchLoggingOptions): any;
+export declare class KinesisFirehoseDeliveryStreamHttpEndpointConfigurationCloudwatchLoggingOptionsOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamHttpEndpointConfigurationCloudwatchLoggingOptions | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamHttpEndpointConfigurationCloudwatchLoggingOptions | undefined);
+    private _enabled?;
+    get enabled(): boolean | cdktf.IResolvable;
+    set enabled(value: boolean | cdktf.IResolvable);
+    resetEnabled(): void;
+    get enabledInput(): boolean | cdktf.IResolvable | undefined;
+    private _logGroupName?;
+    get logGroupName(): string;
+    set logGroupName(value: string);
+    resetLogGroupName(): void;
+    get logGroupNameInput(): string | undefined;
+    private _logStreamName?;
+    get logStreamName(): string;
+    set logStreamName(value: string);
+    resetLogStreamName(): void;
+    get logStreamNameInput(): string | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamHttpEndpointConfigurationProcessingConfigurationProcessorsParameters {
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#parameter_name KinesisFirehoseDeliveryStream#parameter_name}
+    */
+    readonly parameterName: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#parameter_value KinesisFirehoseDeliveryStream#parameter_value}
+    */
+    readonly parameterValue: string;
+}
+export declare function kinesisFirehoseDeliveryStreamHttpEndpointConfigurationProcessingConfigurationProcessorsParametersToTerraform(struct?: KinesisFirehoseDeliveryStreamHttpEndpointConfigurationProcessingConfigurationProcessorsParameters | cdktf.IResolvable): any;
+export declare function kinesisFirehoseDeliveryStreamHttpEndpointConfigurationProcessingConfigurationProcessorsParametersToHclTerraform(struct?: KinesisFirehoseDeliveryStreamHttpEndpointConfigurationProcessingConfigurationProcessorsParameters | cdktf.IResolvable): any;
+export declare class KinesisFirehoseDeliveryStreamHttpEndpointConfigurationProcessingConfigurationProcessorsParametersOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    private resolvableValue?;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    * @param complexObjectIndex the index of this item in the list
+    * @param complexObjectIsFromSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string, complexObjectIndex: number, complexObjectIsFromSet: boolean);
+    get internalValue(): KinesisFirehoseDeliveryStreamHttpEndpointConfigurationProcessingConfigurationProcessorsParameters | cdktf.IResolvable | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamHttpEndpointConfigurationProcessingConfigurationProcessorsParameters | cdktf.IResolvable | undefined);
+    private _parameterName?;
+    get parameterName(): string;
+    set parameterName(value: string);
+    get parameterNameInput(): string | undefined;
+    private _parameterValue?;
+    get parameterValue(): string;
+    set parameterValue(value: string);
+    get parameterValueInput(): string | undefined;
+}
+export declare class KinesisFirehoseDeliveryStreamHttpEndpointConfigurationProcessingConfigurationProcessorsParametersList extends cdktf.ComplexList {
+    protected terraformResource: cdktf.IInterpolatingParent;
+    protected terraformAttribute: string;
+    protected wrapsSet: boolean;
+    internalValue?: KinesisFirehoseDeliveryStreamHttpEndpointConfigurationProcessingConfigurationProcessorsParameters[] | cdktf.IResolvable;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    * @param wrapsSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string, wrapsSet: boolean);
+    /**
+    * @param index the index of the item to return
+    */
+    get(index: number): KinesisFirehoseDeliveryStreamHttpEndpointConfigurationProcessingConfigurationProcessorsParametersOutputReference;
+}
+export interface KinesisFirehoseDeliveryStreamHttpEndpointConfigurationProcessingConfigurationProcessors {
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#type KinesisFirehoseDeliveryStream#type}
+    */
+    readonly type: string;
+    /**
+    * parameters block
+    *
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#parameters KinesisFirehoseDeliveryStream#parameters}
+    */
+    readonly parameters?: KinesisFirehoseDeliveryStreamHttpEndpointConfigurationProcessingConfigurationProcessorsParameters[] | cdktf.IResolvable;
+}
+export declare function kinesisFirehoseDeliveryStreamHttpEndpointConfigurationProcessingConfigurationProcessorsToTerraform(struct?: KinesisFirehoseDeliveryStreamHttpEndpointConfigurationProcessingConfigurationProcessors | cdktf.IResolvable): any;
+export declare function kinesisFirehoseDeliveryStreamHttpEndpointConfigurationProcessingConfigurationProcessorsToHclTerraform(struct?: KinesisFirehoseDeliveryStreamHttpEndpointConfigurationProcessingConfigurationProcessors | cdktf.IResolvable): any;
+export declare class KinesisFirehoseDeliveryStreamHttpEndpointConfigurationProcessingConfigurationProcessorsOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    private resolvableValue?;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    * @param complexObjectIndex the index of this item in the list
+    * @param complexObjectIsFromSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string, complexObjectIndex: number, complexObjectIsFromSet: boolean);
+    get internalValue(): KinesisFirehoseDeliveryStreamHttpEndpointConfigurationProcessingConfigurationProcessors | cdktf.IResolvable | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamHttpEndpointConfigurationProcessingConfigurationProcessors | cdktf.IResolvable | undefined);
+    private _type?;
+    get type(): string;
+    set type(value: string);
+    get typeInput(): string | undefined;
+    private _parameters;
+    get parameters(): KinesisFirehoseDeliveryStreamHttpEndpointConfigurationProcessingConfigurationProcessorsParametersList;
+    putParameters(value: KinesisFirehoseDeliveryStreamHttpEndpointConfigurationProcessingConfigurationProcessorsParameters[] | cdktf.IResolvable): void;
+    resetParameters(): void;
+    get parametersInput(): cdktf.IResolvable | KinesisFirehoseDeliveryStreamHttpEndpointConfigurationProcessingConfigurationProcessorsParameters[] | undefined;
+}
+export declare class KinesisFirehoseDeliveryStreamHttpEndpointConfigurationProcessingConfigurationProcessorsList extends cdktf.ComplexList {
+    protected terraformResource: cdktf.IInterpolatingParent;
+    protected terraformAttribute: string;
+    protected wrapsSet: boolean;
+    internalValue?: KinesisFirehoseDeliveryStreamHttpEndpointConfigurationProcessingConfigurationProcessors[] | cdktf.IResolvable;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    * @param wrapsSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string, wrapsSet: boolean);
+    /**
+    * @param index the index of the item to return
+    */
+    get(index: number): KinesisFirehoseDeliveryStreamHttpEndpointConfigurationProcessingConfigurationProcessorsOutputReference;
+}
+export interface KinesisFirehoseDeliveryStreamHttpEndpointConfigurationProcessingConfiguration {
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#enabled KinesisFirehoseDeliveryStream#enabled}
+    */
+    readonly enabled?: boolean | cdktf.IResolvable;
+    /**
+    * processors block
+    *
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#processors KinesisFirehoseDeliveryStream#processors}
+    */
+    readonly processors?: KinesisFirehoseDeliveryStreamHttpEndpointConfigurationProcessingConfigurationProcessors[] | cdktf.IResolvable;
+}
+export declare function kinesisFirehoseDeliveryStreamHttpEndpointConfigurationProcessingConfigurationToTerraform(struct?: KinesisFirehoseDeliveryStreamHttpEndpointConfigurationProcessingConfigurationOutputReference | KinesisFirehoseDeliveryStreamHttpEndpointConfigurationProcessingConfiguration): any;
+export declare function kinesisFirehoseDeliveryStreamHttpEndpointConfigurationProcessingConfigurationToHclTerraform(struct?: KinesisFirehoseDeliveryStreamHttpEndpointConfigurationProcessingConfigurationOutputReference | KinesisFirehoseDeliveryStreamHttpEndpointConfigurationProcessingConfiguration): any;
+export declare class KinesisFirehoseDeliveryStreamHttpEndpointConfigurationProcessingConfigurationOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamHttpEndpointConfigurationProcessingConfiguration | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamHttpEndpointConfigurationProcessingConfiguration | undefined);
+    private _enabled?;
+    get enabled(): boolean | cdktf.IResolvable;
+    set enabled(value: boolean | cdktf.IResolvable);
+    resetEnabled(): void;
+    get enabledInput(): boolean | cdktf.IResolvable | undefined;
+    private _processors;
+    get processors(): KinesisFirehoseDeliveryStreamHttpEndpointConfigurationProcessingConfigurationProcessorsList;
+    putProcessors(value: KinesisFirehoseDeliveryStreamHttpEndpointConfigurationProcessingConfigurationProcessors[] | cdktf.IResolvable): void;
+    resetProcessors(): void;
+    get processorsInput(): cdktf.IResolvable | KinesisFirehoseDeliveryStreamHttpEndpointConfigurationProcessingConfigurationProcessors[] | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamHttpEndpointConfigurationRequestConfigurationCommonAttributes {
+    /** (Required) The name of the HTTP endpoint common attribute. */
+    readonly name: string;
+    /** (Required) The value of the HTTP endpoint common attribute. */
+    readonly value: string;
+}
+export declare function kinesisFirehoseDeliveryStreamHttpEndpointConfigurationRequestConfigurationCommonAttributesToTerraform(struct?: KinesisFirehoseDeliveryStreamHttpEndpointConfigurationRequestConfigurationCommonAttributes | cdktf.IResolvable): any;
+export declare function kinesisFirehoseDeliveryStreamHttpEndpointConfigurationRequestConfigurationCommonAttributesToHclTerraform(struct?: KinesisFirehoseDeliveryStreamHttpEndpointConfigurationRequestConfigurationCommonAttributes | cdktf.IResolvable): any;
+export declare class KinesisFirehoseDeliveryStreamHttpEndpointConfigurationRequestConfigurationCommonAttributesOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    private resolvableValue?;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    * @param complexObjectIndex the index of this item in the list
+    * @param complexObjectIsFromSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string, complexObjectIndex: number, complexObjectIsFromSet: boolean);
+    get internalValue(): KinesisFirehoseDeliveryStreamHttpEndpointConfigurationRequestConfigurationCommonAttributes | cdktf.IResolvable | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamHttpEndpointConfigurationRequestConfigurationCommonAttributes | cdktf.IResolvable | undefined);
+    private _name?;
+    get name(): string;
+    set name(value: string);
+    get nameInput(): string | undefined;
+    private _value?;
+    get value(): string;
+    set value(value: string);
+    get valueInput(): string | undefined;
+}
+export declare class KinesisFirehoseDeliveryStreamHttpEndpointConfigurationRequestConfigurationCommonAttributesList extends cdktf.ComplexList {
+    protected terraformResource: cdktf.IInterpolatingParent;
+    protected terraformAttribute: string;
+    protected wrapsSet: boolean;
+    internalValue?: KinesisFirehoseDeliveryStreamHttpEndpointConfigurationRequestConfigurationCommonAttributes[] | cdktf.IResolvable;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    * @param wrapsSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string, wrapsSet: boolean);
+    /**
+    * @param index the index of the item to return
+    */
+    get(index: number): KinesisFirehoseDeliveryStreamHttpEndpointConfigurationRequestConfigurationCommonAttributesOutputReference;
+}
+export interface KinesisFirehoseDeliveryStreamHttpEndpointConfigurationRequestConfiguration {
+    /** (Optional) Kinesis Data Firehose uses the content encoding to compress the body of a request before sending the request to the destination. Valid values are `NONE` and `GZIP`.  Default value is `NONE`. */
+    readonly contentEncoding?: string;
+    /** */
+    readonly commonAttributes?: KinesisFirehoseDeliveryStreamHttpEndpointConfigurationRequestConfigurationCommonAttributes[] | cdktf.IResolvable;
+}
+export declare function kinesisFirehoseDeliveryStreamHttpEndpointConfigurationRequestConfigurationToTerraform(struct?: KinesisFirehoseDeliveryStreamHttpEndpointConfigurationRequestConfigurationOutputReference | KinesisFirehoseDeliveryStreamHttpEndpointConfigurationRequestConfiguration): any;
+export declare function kinesisFirehoseDeliveryStreamHttpEndpointConfigurationRequestConfigurationToHclTerraform(struct?: KinesisFirehoseDeliveryStreamHttpEndpointConfigurationRequestConfigurationOutputReference | KinesisFirehoseDeliveryStreamHttpEndpointConfigurationRequestConfiguration): any;
+export declare class KinesisFirehoseDeliveryStreamHttpEndpointConfigurationRequestConfigurationOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamHttpEndpointConfigurationRequestConfiguration | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamHttpEndpointConfigurationRequestConfiguration | undefined);
+    private _contentEncoding?;
+    get contentEncoding(): string;
+    set contentEncoding(value: string);
+    resetContentEncoding(): void;
+    get contentEncodingInput(): string | undefined;
+    private _commonAttributes;
+    get commonAttributes(): KinesisFirehoseDeliveryStreamHttpEndpointConfigurationRequestConfigurationCommonAttributesList;
+    putCommonAttributes(value: KinesisFirehoseDeliveryStreamHttpEndpointConfigurationRequestConfigurationCommonAttributes[] | cdktf.IResolvable): void;
+    resetCommonAttributes(): void;
+    get commonAttributesInput(): cdktf.IResolvable | KinesisFirehoseDeliveryStreamHttpEndpointConfigurationRequestConfigurationCommonAttributes[] | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamHttpEndpointConfigurationS3ConfigurationCloudwatchLoggingOptions {
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#enabled KinesisFirehoseDeliveryStream#enabled}
+    */
+    readonly enabled?: boolean | cdktf.IResolvable;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#log_group_name KinesisFirehoseDeliveryStream#log_group_name}
+    */
+    readonly logGroupName?: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#log_stream_name KinesisFirehoseDeliveryStream#log_stream_name}
+    */
+    readonly logStreamName?: string;
+}
+export declare function kinesisFirehoseDeliveryStreamHttpEndpointConfigurationS3ConfigurationCloudwatchLoggingOptionsToTerraform(struct?: KinesisFirehoseDeliveryStreamHttpEndpointConfigurationS3ConfigurationCloudwatchLoggingOptionsOutputReference | KinesisFirehoseDeliveryStreamHttpEndpointConfigurationS3ConfigurationCloudwatchLoggingOptions): any;
+export declare function kinesisFirehoseDeliveryStreamHttpEndpointConfigurationS3ConfigurationCloudwatchLoggingOptionsToHclTerraform(struct?: KinesisFirehoseDeliveryStreamHttpEndpointConfigurationS3ConfigurationCloudwatchLoggingOptionsOutputReference | KinesisFirehoseDeliveryStreamHttpEndpointConfigurationS3ConfigurationCloudwatchLoggingOptions): any;
+export declare class KinesisFirehoseDeliveryStreamHttpEndpointConfigurationS3ConfigurationCloudwatchLoggingOptionsOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamHttpEndpointConfigurationS3ConfigurationCloudwatchLoggingOptions | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamHttpEndpointConfigurationS3ConfigurationCloudwatchLoggingOptions | undefined);
+    private _enabled?;
+    get enabled(): boolean | cdktf.IResolvable;
+    set enabled(value: boolean | cdktf.IResolvable);
+    resetEnabled(): void;
+    get enabledInput(): boolean | cdktf.IResolvable | undefined;
+    private _logGroupName?;
+    get logGroupName(): string;
+    set logGroupName(value: string);
+    resetLogGroupName(): void;
+    get logGroupNameInput(): string | undefined;
+    private _logStreamName?;
+    get logStreamName(): string;
+    set logStreamName(value: string);
+    resetLogStreamName(): void;
+    get logStreamNameInput(): string | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamHttpEndpointConfigurationS3Configuration {
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#bucket_arn KinesisFirehoseDeliveryStream#bucket_arn}
+    */
+    readonly bucketArn: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#buffering_interval KinesisFirehoseDeliveryStream#buffering_interval}
+    */
+    readonly bufferingInterval?: number;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#buffering_size KinesisFirehoseDeliveryStream#buffering_size}
+    */
+    readonly bufferingSize?: number;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#compression_format KinesisFirehoseDeliveryStream#compression_format}
+    */
+    readonly compressionFormat?: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#error_output_prefix KinesisFirehoseDeliveryStream#error_output_prefix}
+    */
+    readonly errorOutputPrefix?: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#kms_key_arn KinesisFirehoseDeliveryStream#kms_key_arn}
+    */
+    readonly kmsKeyArn?: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#prefix KinesisFirehoseDeliveryStream#prefix}
+    */
+    readonly prefix?: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#role_arn KinesisFirehoseDeliveryStream#role_arn}
+    */
+    readonly roleArn: string;
+    /**
+    * cloudwatch_logging_options block
+    *
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#cloudwatch_logging_options KinesisFirehoseDeliveryStream#cloudwatch_logging_options}
+    */
+    readonly cloudwatchLoggingOptions?: KinesisFirehoseDeliveryStreamHttpEndpointConfigurationS3ConfigurationCloudwatchLoggingOptions;
+}
+export declare function kinesisFirehoseDeliveryStreamHttpEndpointConfigurationS3ConfigurationToTerraform(struct?: KinesisFirehoseDeliveryStreamHttpEndpointConfigurationS3ConfigurationOutputReference | KinesisFirehoseDeliveryStreamHttpEndpointConfigurationS3Configuration): any;
+export declare function kinesisFirehoseDeliveryStreamHttpEndpointConfigurationS3ConfigurationToHclTerraform(struct?: KinesisFirehoseDeliveryStreamHttpEndpointConfigurationS3ConfigurationOutputReference | KinesisFirehoseDeliveryStreamHttpEndpointConfigurationS3Configuration): any;
+export declare class KinesisFirehoseDeliveryStreamHttpEndpointConfigurationS3ConfigurationOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamHttpEndpointConfigurationS3Configuration | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamHttpEndpointConfigurationS3Configuration | undefined);
+    private _bucketArn?;
+    get bucketArn(): string;
+    set bucketArn(value: string);
+    get bucketArnInput(): string | undefined;
+    private _bufferingInterval?;
+    get bufferingInterval(): number;
+    set bufferingInterval(value: number);
+    resetBufferingInterval(): void;
+    get bufferingIntervalInput(): number | undefined;
+    private _bufferingSize?;
+    get bufferingSize(): number;
+    set bufferingSize(value: number);
+    resetBufferingSize(): void;
+    get bufferingSizeInput(): number | undefined;
+    private _compressionFormat?;
+    get compressionFormat(): string;
+    set compressionFormat(value: string);
+    resetCompressionFormat(): void;
+    get compressionFormatInput(): string | undefined;
+    private _errorOutputPrefix?;
+    get errorOutputPrefix(): string;
+    set errorOutputPrefix(value: string);
+    resetErrorOutputPrefix(): void;
+    get errorOutputPrefixInput(): string | undefined;
+    private _kmsKeyArn?;
+    get kmsKeyArn(): string;
+    set kmsKeyArn(value: string);
+    resetKmsKeyArn(): void;
+    get kmsKeyArnInput(): string | undefined;
+    private _prefix?;
+    get prefix(): string;
+    set prefix(value: string);
+    resetPrefix(): void;
+    get prefixInput(): string | undefined;
+    private _roleArn?;
+    get roleArn(): string;
+    set roleArn(value: string);
+    get roleArnInput(): string | undefined;
+    private _cloudwatchLoggingOptions;
+    get cloudwatchLoggingOptions(): KinesisFirehoseDeliveryStreamHttpEndpointConfigurationS3ConfigurationCloudwatchLoggingOptionsOutputReference;
+    putCloudwatchLoggingOptions(value: KinesisFirehoseDeliveryStreamHttpEndpointConfigurationS3ConfigurationCloudwatchLoggingOptions): void;
+    resetCloudwatchLoggingOptions(): void;
+    get cloudwatchLoggingOptionsInput(): KinesisFirehoseDeliveryStreamHttpEndpointConfigurationS3ConfigurationCloudwatchLoggingOptions | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamHttpEndpointConfigurationSecretsManagerConfiguration {
+    /** (Optional) Enables or disables the Secrets Manager configuration. */
+    readonly enabled?: boolean | cdktf.IResolvable;
+    /** (Optional) The ARN of the Secrets Manager secret. This value is required if `enabled` is true. */
+    readonly roleArn?: string;
+    /** (Optional) The ARN of the Secrets Manager secret. This value is required if `enabled` is true. */
+    readonly secretArn?: string;
+}
+export declare function kinesisFirehoseDeliveryStreamHttpEndpointConfigurationSecretsManagerConfigurationToTerraform(struct?: KinesisFirehoseDeliveryStreamHttpEndpointConfigurationSecretsManagerConfigurationOutputReference | KinesisFirehoseDeliveryStreamHttpEndpointConfigurationSecretsManagerConfiguration): any;
+export declare function kinesisFirehoseDeliveryStreamHttpEndpointConfigurationSecretsManagerConfigurationToHclTerraform(struct?: KinesisFirehoseDeliveryStreamHttpEndpointConfigurationSecretsManagerConfigurationOutputReference | KinesisFirehoseDeliveryStreamHttpEndpointConfigurationSecretsManagerConfiguration): any;
+export declare class KinesisFirehoseDeliveryStreamHttpEndpointConfigurationSecretsManagerConfigurationOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamHttpEndpointConfigurationSecretsManagerConfiguration | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamHttpEndpointConfigurationSecretsManagerConfiguration | undefined);
+    private _enabled?;
+    get enabled(): boolean | cdktf.IResolvable;
+    set enabled(value: boolean | cdktf.IResolvable);
+    resetEnabled(): void;
+    get enabledInput(): boolean | cdktf.IResolvable | undefined;
+    private _roleArn?;
+    get roleArn(): string;
+    set roleArn(value: string);
+    resetRoleArn(): void;
+    get roleArnInput(): string | undefined;
+    private _secretArn?;
+    get secretArn(): string;
+    set secretArn(value: string);
+    resetSecretArn(): void;
+    get secretArnInput(): string | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamHttpEndpointConfiguration {
+    /** (Optional) The access key required for Kinesis Firehose to authenticate with the HTTP endpoint selected as the destination. */
+    readonly accessKey?: string;
+    /** (Optional) Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. The default value is 300 (5 minutes). */
+    readonly bufferingInterval?: number;
+    /** (Optional) Buffer incoming data to the specified size, in MBs, before delivering it to the destination. The default value is 5. */
+    readonly bufferingSize?: number;
+    /** (Optional) The HTTP endpoint name. */
+    readonly name?: string;
+    /** (Optional) Total amount of seconds Firehose spends on retries. This duration starts after the initial attempt fails, It does not include the time periods during which Firehose waits for acknowledgment from the specified destination after each attempt. Valid values between `0` and `7200`. Default is `300`. */
+    readonly retryDuration?: number;
+    /** (Required) Kinesis Data Firehose uses this IAM role for all the permissions that the delivery stream needs. The pattern needs to be `arn:.*`. */
+    readonly roleArn?: string;
+    /** (Optional) Defines how documents should be delivered to Amazon S3.  Valid values are `FailedDataOnly` and `AllData`.  Default value is `FailedDataOnly`. */
+    readonly s3BackupMode?: string;
+    /** (Required) The HTTP endpoint URL to which Kinesis Firehose sends your data. */
+    readonly url: string;
+    /** */
+    readonly cloudwatchLoggingOptions?: KinesisFirehoseDeliveryStreamHttpEndpointConfigurationCloudwatchLoggingOptions;
+    /** */
+    readonly processingConfiguration?: KinesisFirehoseDeliveryStreamHttpEndpointConfigurationProcessingConfiguration;
+    /** */
+    readonly requestConfiguration?: KinesisFirehoseDeliveryStreamHttpEndpointConfigurationRequestConfiguration;
+    /** */
+    readonly s3Configuration: KinesisFirehoseDeliveryStreamHttpEndpointConfigurationS3Configuration;
+    /** */
+    readonly secretsManagerConfiguration?: KinesisFirehoseDeliveryStreamHttpEndpointConfigurationSecretsManagerConfiguration;
+}
+export declare function kinesisFirehoseDeliveryStreamHttpEndpointConfigurationToTerraform(struct?: KinesisFirehoseDeliveryStreamHttpEndpointConfigurationOutputReference | KinesisFirehoseDeliveryStreamHttpEndpointConfiguration): any;
+export declare function kinesisFirehoseDeliveryStreamHttpEndpointConfigurationToHclTerraform(struct?: KinesisFirehoseDeliveryStreamHttpEndpointConfigurationOutputReference | KinesisFirehoseDeliveryStreamHttpEndpointConfiguration): any;
+export declare class KinesisFirehoseDeliveryStreamHttpEndpointConfigurationOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamHttpEndpointConfiguration | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamHttpEndpointConfiguration | undefined);
+    private _accessKey?;
+    get accessKey(): string;
+    set accessKey(value: string);
+    resetAccessKey(): void;
+    get accessKeyInput(): string | undefined;
+    private _bufferingInterval?;
+    get bufferingInterval(): number;
+    set bufferingInterval(value: number);
+    resetBufferingInterval(): void;
+    get bufferingIntervalInput(): number | undefined;
+    private _bufferingSize?;
+    get bufferingSize(): number;
+    set bufferingSize(value: number);
+    resetBufferingSize(): void;
+    get bufferingSizeInput(): number | undefined;
+    private _name?;
+    get name(): string;
+    set name(value: string);
+    resetName(): void;
+    get nameInput(): string | undefined;
+    private _retryDuration?;
+    get retryDuration(): number;
+    set retryDuration(value: number);
+    resetRetryDuration(): void;
+    get retryDurationInput(): number | undefined;
+    private _roleArn?;
+    get roleArn(): string;
+    set roleArn(value: string);
+    resetRoleArn(): void;
+    get roleArnInput(): string | undefined;
+    private _s3BackupMode?;
+    get s3BackupMode(): string;
+    set s3BackupMode(value: string);
+    resetS3BackupMode(): void;
+    get s3BackupModeInput(): string | undefined;
+    private _url?;
+    get url(): string;
+    set url(value: string);
+    get urlInput(): string | undefined;
+    private _cloudwatchLoggingOptions;
+    get cloudwatchLoggingOptions(): KinesisFirehoseDeliveryStreamHttpEndpointConfigurationCloudwatchLoggingOptionsOutputReference;
+    putCloudwatchLoggingOptions(value: KinesisFirehoseDeliveryStreamHttpEndpointConfigurationCloudwatchLoggingOptions): void;
+    resetCloudwatchLoggingOptions(): void;
+    get cloudwatchLoggingOptionsInput(): KinesisFirehoseDeliveryStreamHttpEndpointConfigurationCloudwatchLoggingOptions | undefined;
+    private _processingConfiguration;
+    get processingConfiguration(): KinesisFirehoseDeliveryStreamHttpEndpointConfigurationProcessingConfigurationOutputReference;
+    putProcessingConfiguration(value: KinesisFirehoseDeliveryStreamHttpEndpointConfigurationProcessingConfiguration): void;
+    resetProcessingConfiguration(): void;
+    get processingConfigurationInput(): KinesisFirehoseDeliveryStreamHttpEndpointConfigurationProcessingConfiguration | undefined;
+    private _requestConfiguration;
+    get requestConfiguration(): KinesisFirehoseDeliveryStreamHttpEndpointConfigurationRequestConfigurationOutputReference;
+    putRequestConfiguration(value: KinesisFirehoseDeliveryStreamHttpEndpointConfigurationRequestConfiguration): void;
+    resetRequestConfiguration(): void;
+    get requestConfigurationInput(): KinesisFirehoseDeliveryStreamHttpEndpointConfigurationRequestConfiguration | undefined;
+    private _s3Configuration;
+    get s3Configuration(): KinesisFirehoseDeliveryStreamHttpEndpointConfigurationS3ConfigurationOutputReference;
+    putS3Configuration(value: KinesisFirehoseDeliveryStreamHttpEndpointConfigurationS3Configuration): void;
+    get s3ConfigurationInput(): KinesisFirehoseDeliveryStreamHttpEndpointConfigurationS3Configuration | undefined;
+    private _secretsManagerConfiguration;
+    get secretsManagerConfiguration(): KinesisFirehoseDeliveryStreamHttpEndpointConfigurationSecretsManagerConfigurationOutputReference;
+    putSecretsManagerConfiguration(value: KinesisFirehoseDeliveryStreamHttpEndpointConfigurationSecretsManagerConfiguration): void;
+    resetSecretsManagerConfiguration(): void;
+    get secretsManagerConfigurationInput(): KinesisFirehoseDeliveryStreamHttpEndpointConfigurationSecretsManagerConfiguration | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamIcebergConfigurationCloudwatchLoggingOptions {
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#enabled KinesisFirehoseDeliveryStream#enabled}
+    */
+    readonly enabled?: boolean | cdktf.IResolvable;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#log_group_name KinesisFirehoseDeliveryStream#log_group_name}
+    */
+    readonly logGroupName?: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#log_stream_name KinesisFirehoseDeliveryStream#log_stream_name}
+    */
+    readonly logStreamName?: string;
+}
+export declare function kinesisFirehoseDeliveryStreamIcebergConfigurationCloudwatchLoggingOptionsToTerraform(struct?: KinesisFirehoseDeliveryStreamIcebergConfigurationCloudwatchLoggingOptionsOutputReference | KinesisFirehoseDeliveryStreamIcebergConfigurationCloudwatchLoggingOptions): any;
+export declare function kinesisFirehoseDeliveryStreamIcebergConfigurationCloudwatchLoggingOptionsToHclTerraform(struct?: KinesisFirehoseDeliveryStreamIcebergConfigurationCloudwatchLoggingOptionsOutputReference | KinesisFirehoseDeliveryStreamIcebergConfigurationCloudwatchLoggingOptions): any;
+export declare class KinesisFirehoseDeliveryStreamIcebergConfigurationCloudwatchLoggingOptionsOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamIcebergConfigurationCloudwatchLoggingOptions | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamIcebergConfigurationCloudwatchLoggingOptions | undefined);
+    private _enabled?;
+    get enabled(): boolean | cdktf.IResolvable;
+    set enabled(value: boolean | cdktf.IResolvable);
+    resetEnabled(): void;
+    get enabledInput(): boolean | cdktf.IResolvable | undefined;
+    private _logGroupName?;
+    get logGroupName(): string;
+    set logGroupName(value: string);
+    resetLogGroupName(): void;
+    get logGroupNameInput(): string | undefined;
+    private _logStreamName?;
+    get logStreamName(): string;
+    set logStreamName(value: string);
+    resetLogStreamName(): void;
+    get logStreamNameInput(): string | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamIcebergConfigurationDestinationTableConfiguration {
+    /** (Required) The name of the Apache Iceberg database. */
+    readonly databaseName: string;
+    /** (Optional) The table specific S3 error output prefix. All the errors that occurred while delivering to this table will be prefixed with this value in S3 destination. */
+    readonly s3ErrorOutputPrefix?: string;
+    /** (Required) The name of the Apache Iceberg Table. */
+    readonly tableName: string;
+    /** (Optional) A list of unique keys for a given Apache Iceberg table. Firehose will use these for running Create, Update, or Delete operations on the given Iceberg table. */
+    readonly uniqueKeys?: string[];
+}
+export declare function kinesisFirehoseDeliveryStreamIcebergConfigurationDestinationTableConfigurationToTerraform(struct?: KinesisFirehoseDeliveryStreamIcebergConfigurationDestinationTableConfiguration | cdktf.IResolvable): any;
+export declare function kinesisFirehoseDeliveryStreamIcebergConfigurationDestinationTableConfigurationToHclTerraform(struct?: KinesisFirehoseDeliveryStreamIcebergConfigurationDestinationTableConfiguration | cdktf.IResolvable): any;
+export declare class KinesisFirehoseDeliveryStreamIcebergConfigurationDestinationTableConfigurationOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    private resolvableValue?;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    * @param complexObjectIndex the index of this item in the list
+    * @param complexObjectIsFromSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string, complexObjectIndex: number, complexObjectIsFromSet: boolean);
+    get internalValue(): KinesisFirehoseDeliveryStreamIcebergConfigurationDestinationTableConfiguration | cdktf.IResolvable | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamIcebergConfigurationDestinationTableConfiguration | cdktf.IResolvable | undefined);
+    private _databaseName?;
+    get databaseName(): string;
+    set databaseName(value: string);
+    get databaseNameInput(): string | undefined;
+    private _s3ErrorOutputPrefix?;
+    get s3ErrorOutputPrefix(): string;
+    set s3ErrorOutputPrefix(value: string);
+    resetS3ErrorOutputPrefix(): void;
+    get s3ErrorOutputPrefixInput(): string | undefined;
+    private _tableName?;
+    get tableName(): string;
+    set tableName(value: string);
+    get tableNameInput(): string | undefined;
+    private _uniqueKeys?;
+    get uniqueKeys(): string[];
+    set uniqueKeys(value: string[]);
+    resetUniqueKeys(): void;
+    get uniqueKeysInput(): string[] | undefined;
+}
+export declare class KinesisFirehoseDeliveryStreamIcebergConfigurationDestinationTableConfigurationList extends cdktf.ComplexList {
+    protected terraformResource: cdktf.IInterpolatingParent;
+    protected terraformAttribute: string;
+    protected wrapsSet: boolean;
+    internalValue?: KinesisFirehoseDeliveryStreamIcebergConfigurationDestinationTableConfiguration[] | cdktf.IResolvable;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    * @param wrapsSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string, wrapsSet: boolean);
+    /**
+    * @param index the index of the item to return
+    */
+    get(index: number): KinesisFirehoseDeliveryStreamIcebergConfigurationDestinationTableConfigurationOutputReference;
+}
+export interface KinesisFirehoseDeliveryStreamIcebergConfigurationProcessingConfigurationProcessorsParameters {
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#parameter_name KinesisFirehoseDeliveryStream#parameter_name}
+    */
+    readonly parameterName: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#parameter_value KinesisFirehoseDeliveryStream#parameter_value}
+    */
+    readonly parameterValue: string;
+}
+export declare function kinesisFirehoseDeliveryStreamIcebergConfigurationProcessingConfigurationProcessorsParametersToTerraform(struct?: KinesisFirehoseDeliveryStreamIcebergConfigurationProcessingConfigurationProcessorsParameters | cdktf.IResolvable): any;
+export declare function kinesisFirehoseDeliveryStreamIcebergConfigurationProcessingConfigurationProcessorsParametersToHclTerraform(struct?: KinesisFirehoseDeliveryStreamIcebergConfigurationProcessingConfigurationProcessorsParameters | cdktf.IResolvable): any;
+export declare class KinesisFirehoseDeliveryStreamIcebergConfigurationProcessingConfigurationProcessorsParametersOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    private resolvableValue?;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    * @param complexObjectIndex the index of this item in the list
+    * @param complexObjectIsFromSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string, complexObjectIndex: number, complexObjectIsFromSet: boolean);
+    get internalValue(): KinesisFirehoseDeliveryStreamIcebergConfigurationProcessingConfigurationProcessorsParameters | cdktf.IResolvable | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamIcebergConfigurationProcessingConfigurationProcessorsParameters | cdktf.IResolvable | undefined);
+    private _parameterName?;
+    get parameterName(): string;
+    set parameterName(value: string);
+    get parameterNameInput(): string | undefined;
+    private _parameterValue?;
+    get parameterValue(): string;
+    set parameterValue(value: string);
+    get parameterValueInput(): string | undefined;
+}
+export declare class KinesisFirehoseDeliveryStreamIcebergConfigurationProcessingConfigurationProcessorsParametersList extends cdktf.ComplexList {
+    protected terraformResource: cdktf.IInterpolatingParent;
+    protected terraformAttribute: string;
+    protected wrapsSet: boolean;
+    internalValue?: KinesisFirehoseDeliveryStreamIcebergConfigurationProcessingConfigurationProcessorsParameters[] | cdktf.IResolvable;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    * @param wrapsSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string, wrapsSet: boolean);
+    /**
+    * @param index the index of the item to return
+    */
+    get(index: number): KinesisFirehoseDeliveryStreamIcebergConfigurationProcessingConfigurationProcessorsParametersOutputReference;
+}
+export interface KinesisFirehoseDeliveryStreamIcebergConfigurationProcessingConfigurationProcessors {
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#type KinesisFirehoseDeliveryStream#type}
+    */
+    readonly type: string;
+    /**
+    * parameters block
+    *
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#parameters KinesisFirehoseDeliveryStream#parameters}
+    */
+    readonly parameters?: KinesisFirehoseDeliveryStreamIcebergConfigurationProcessingConfigurationProcessorsParameters[] | cdktf.IResolvable;
+}
+export declare function kinesisFirehoseDeliveryStreamIcebergConfigurationProcessingConfigurationProcessorsToTerraform(struct?: KinesisFirehoseDeliveryStreamIcebergConfigurationProcessingConfigurationProcessors | cdktf.IResolvable): any;
+export declare function kinesisFirehoseDeliveryStreamIcebergConfigurationProcessingConfigurationProcessorsToHclTerraform(struct?: KinesisFirehoseDeliveryStreamIcebergConfigurationProcessingConfigurationProcessors | cdktf.IResolvable): any;
+export declare class KinesisFirehoseDeliveryStreamIcebergConfigurationProcessingConfigurationProcessorsOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    private resolvableValue?;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    * @param complexObjectIndex the index of this item in the list
+    * @param complexObjectIsFromSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string, complexObjectIndex: number, complexObjectIsFromSet: boolean);
+    get internalValue(): KinesisFirehoseDeliveryStreamIcebergConfigurationProcessingConfigurationProcessors | cdktf.IResolvable | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamIcebergConfigurationProcessingConfigurationProcessors | cdktf.IResolvable | undefined);
+    private _type?;
+    get type(): string;
+    set type(value: string);
+    get typeInput(): string | undefined;
+    private _parameters;
+    get parameters(): KinesisFirehoseDeliveryStreamIcebergConfigurationProcessingConfigurationProcessorsParametersList;
+    putParameters(value: KinesisFirehoseDeliveryStreamIcebergConfigurationProcessingConfigurationProcessorsParameters[] | cdktf.IResolvable): void;
+    resetParameters(): void;
+    get parametersInput(): cdktf.IResolvable | KinesisFirehoseDeliveryStreamIcebergConfigurationProcessingConfigurationProcessorsParameters[] | undefined;
+}
+export declare class KinesisFirehoseDeliveryStreamIcebergConfigurationProcessingConfigurationProcessorsList extends cdktf.ComplexList {
+    protected terraformResource: cdktf.IInterpolatingParent;
+    protected terraformAttribute: string;
+    protected wrapsSet: boolean;
+    internalValue?: KinesisFirehoseDeliveryStreamIcebergConfigurationProcessingConfigurationProcessors[] | cdktf.IResolvable;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    * @param wrapsSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string, wrapsSet: boolean);
+    /**
+    * @param index the index of the item to return
+    */
+    get(index: number): KinesisFirehoseDeliveryStreamIcebergConfigurationProcessingConfigurationProcessorsOutputReference;
+}
+export interface KinesisFirehoseDeliveryStreamIcebergConfigurationProcessingConfiguration {
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#enabled KinesisFirehoseDeliveryStream#enabled}
+    */
+    readonly enabled?: boolean | cdktf.IResolvable;
+    /**
+    * processors block
+    *
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#processors KinesisFirehoseDeliveryStream#processors}
+    */
+    readonly processors?: KinesisFirehoseDeliveryStreamIcebergConfigurationProcessingConfigurationProcessors[] | cdktf.IResolvable;
+}
+export declare function kinesisFirehoseDeliveryStreamIcebergConfigurationProcessingConfigurationToTerraform(struct?: KinesisFirehoseDeliveryStreamIcebergConfigurationProcessingConfigurationOutputReference | KinesisFirehoseDeliveryStreamIcebergConfigurationProcessingConfiguration): any;
+export declare function kinesisFirehoseDeliveryStreamIcebergConfigurationProcessingConfigurationToHclTerraform(struct?: KinesisFirehoseDeliveryStreamIcebergConfigurationProcessingConfigurationOutputReference | KinesisFirehoseDeliveryStreamIcebergConfigurationProcessingConfiguration): any;
+export declare class KinesisFirehoseDeliveryStreamIcebergConfigurationProcessingConfigurationOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamIcebergConfigurationProcessingConfiguration | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamIcebergConfigurationProcessingConfiguration | undefined);
+    private _enabled?;
+    get enabled(): boolean | cdktf.IResolvable;
+    set enabled(value: boolean | cdktf.IResolvable);
+    resetEnabled(): void;
+    get enabledInput(): boolean | cdktf.IResolvable | undefined;
+    private _processors;
+    get processors(): KinesisFirehoseDeliveryStreamIcebergConfigurationProcessingConfigurationProcessorsList;
+    putProcessors(value: KinesisFirehoseDeliveryStreamIcebergConfigurationProcessingConfigurationProcessors[] | cdktf.IResolvable): void;
+    resetProcessors(): void;
+    get processorsInput(): cdktf.IResolvable | KinesisFirehoseDeliveryStreamIcebergConfigurationProcessingConfigurationProcessors[] | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamIcebergConfigurationS3ConfigurationCloudwatchLoggingOptions {
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#enabled KinesisFirehoseDeliveryStream#enabled}
+    */
+    readonly enabled?: boolean | cdktf.IResolvable;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#log_group_name KinesisFirehoseDeliveryStream#log_group_name}
+    */
+    readonly logGroupName?: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#log_stream_name KinesisFirehoseDeliveryStream#log_stream_name}
+    */
+    readonly logStreamName?: string;
+}
+export declare function kinesisFirehoseDeliveryStreamIcebergConfigurationS3ConfigurationCloudwatchLoggingOptionsToTerraform(struct?: KinesisFirehoseDeliveryStreamIcebergConfigurationS3ConfigurationCloudwatchLoggingOptionsOutputReference | KinesisFirehoseDeliveryStreamIcebergConfigurationS3ConfigurationCloudwatchLoggingOptions): any;
+export declare function kinesisFirehoseDeliveryStreamIcebergConfigurationS3ConfigurationCloudwatchLoggingOptionsToHclTerraform(struct?: KinesisFirehoseDeliveryStreamIcebergConfigurationS3ConfigurationCloudwatchLoggingOptionsOutputReference | KinesisFirehoseDeliveryStreamIcebergConfigurationS3ConfigurationCloudwatchLoggingOptions): any;
+export declare class KinesisFirehoseDeliveryStreamIcebergConfigurationS3ConfigurationCloudwatchLoggingOptionsOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamIcebergConfigurationS3ConfigurationCloudwatchLoggingOptions | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamIcebergConfigurationS3ConfigurationCloudwatchLoggingOptions | undefined);
+    private _enabled?;
+    get enabled(): boolean | cdktf.IResolvable;
+    set enabled(value: boolean | cdktf.IResolvable);
+    resetEnabled(): void;
+    get enabledInput(): boolean | cdktf.IResolvable | undefined;
+    private _logGroupName?;
+    get logGroupName(): string;
+    set logGroupName(value: string);
+    resetLogGroupName(): void;
+    get logGroupNameInput(): string | undefined;
+    private _logStreamName?;
+    get logStreamName(): string;
+    set logStreamName(value: string);
+    resetLogStreamName(): void;
+    get logStreamNameInput(): string | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamIcebergConfigurationS3Configuration {
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#bucket_arn KinesisFirehoseDeliveryStream#bucket_arn}
+    */
+    readonly bucketArn: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#buffering_interval KinesisFirehoseDeliveryStream#buffering_interval}
+    */
+    readonly bufferingInterval?: number;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#buffering_size KinesisFirehoseDeliveryStream#buffering_size}
+    */
+    readonly bufferingSize?: number;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#compression_format KinesisFirehoseDeliveryStream#compression_format}
+    */
+    readonly compressionFormat?: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#error_output_prefix KinesisFirehoseDeliveryStream#error_output_prefix}
+    */
+    readonly errorOutputPrefix?: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#kms_key_arn KinesisFirehoseDeliveryStream#kms_key_arn}
+    */
+    readonly kmsKeyArn?: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#prefix KinesisFirehoseDeliveryStream#prefix}
+    */
+    readonly prefix?: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#role_arn KinesisFirehoseDeliveryStream#role_arn}
+    */
+    readonly roleArn: string;
+    /**
+    * cloudwatch_logging_options block
+    *
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#cloudwatch_logging_options KinesisFirehoseDeliveryStream#cloudwatch_logging_options}
+    */
+    readonly cloudwatchLoggingOptions?: KinesisFirehoseDeliveryStreamIcebergConfigurationS3ConfigurationCloudwatchLoggingOptions;
+}
+export declare function kinesisFirehoseDeliveryStreamIcebergConfigurationS3ConfigurationToTerraform(struct?: KinesisFirehoseDeliveryStreamIcebergConfigurationS3ConfigurationOutputReference | KinesisFirehoseDeliveryStreamIcebergConfigurationS3Configuration): any;
+export declare function kinesisFirehoseDeliveryStreamIcebergConfigurationS3ConfigurationToHclTerraform(struct?: KinesisFirehoseDeliveryStreamIcebergConfigurationS3ConfigurationOutputReference | KinesisFirehoseDeliveryStreamIcebergConfigurationS3Configuration): any;
+export declare class KinesisFirehoseDeliveryStreamIcebergConfigurationS3ConfigurationOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamIcebergConfigurationS3Configuration | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamIcebergConfigurationS3Configuration | undefined);
+    private _bucketArn?;
+    get bucketArn(): string;
+    set bucketArn(value: string);
+    get bucketArnInput(): string | undefined;
+    private _bufferingInterval?;
+    get bufferingInterval(): number;
+    set bufferingInterval(value: number);
+    resetBufferingInterval(): void;
+    get bufferingIntervalInput(): number | undefined;
+    private _bufferingSize?;
+    get bufferingSize(): number;
+    set bufferingSize(value: number);
+    resetBufferingSize(): void;
+    get bufferingSizeInput(): number | undefined;
+    private _compressionFormat?;
+    get compressionFormat(): string;
+    set compressionFormat(value: string);
+    resetCompressionFormat(): void;
+    get compressionFormatInput(): string | undefined;
+    private _errorOutputPrefix?;
+    get errorOutputPrefix(): string;
+    set errorOutputPrefix(value: string);
+    resetErrorOutputPrefix(): void;
+    get errorOutputPrefixInput(): string | undefined;
+    private _kmsKeyArn?;
+    get kmsKeyArn(): string;
+    set kmsKeyArn(value: string);
+    resetKmsKeyArn(): void;
+    get kmsKeyArnInput(): string | undefined;
+    private _prefix?;
+    get prefix(): string;
+    set prefix(value: string);
+    resetPrefix(): void;
+    get prefixInput(): string | undefined;
+    private _roleArn?;
+    get roleArn(): string;
+    set roleArn(value: string);
+    get roleArnInput(): string | undefined;
+    private _cloudwatchLoggingOptions;
+    get cloudwatchLoggingOptions(): KinesisFirehoseDeliveryStreamIcebergConfigurationS3ConfigurationCloudwatchLoggingOptionsOutputReference;
+    putCloudwatchLoggingOptions(value: KinesisFirehoseDeliveryStreamIcebergConfigurationS3ConfigurationCloudwatchLoggingOptions): void;
+    resetCloudwatchLoggingOptions(): void;
+    get cloudwatchLoggingOptionsInput(): KinesisFirehoseDeliveryStreamIcebergConfigurationS3ConfigurationCloudwatchLoggingOptions | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamIcebergConfiguration {
+    /** (Optional) Buffer incoming data for the specified period of time, in seconds between 0 and 900, before delivering it to the destination. The default value is 300. */
+    readonly bufferingInterval?: number;
+    /** (Optional) Buffer incoming data to the specified size, in MBs between 1 and 128, before delivering it to the destination. The default value is 5. */
+    readonly bufferingSize?: number;
+    /** (Required) Glue catalog ARN identifier of the destination Apache Iceberg Tables. You must specify the ARN in the format `arn:aws:glue:region:account-id:catalog` */
+    readonly catalogArn: string;
+    /** (Optional) The period of time, in seconds between 0 to 7200, during which Firehose retries to deliver data to the specified destination. */
+    readonly retryDuration?: number;
+    /** (Required) The ARN of the IAM role to be assumed by Firehose for calling Apache Iceberg Tables. */
+    readonly roleArn: string;
+    /** (Optional) Defines how documents should be delivered to Amazon S3.  Valid values are `FailedDataOnly` and `AllData`.  Default value is `FailedDataOnly`. */
+    readonly s3BackupMode?: string;
+    /** */
+    readonly cloudwatchLoggingOptions?: KinesisFirehoseDeliveryStreamIcebergConfigurationCloudwatchLoggingOptions;
+    /** */
+    readonly destinationTableConfiguration?: KinesisFirehoseDeliveryStreamIcebergConfigurationDestinationTableConfiguration[] | cdktf.IResolvable;
+    /** */
+    readonly processingConfiguration?: KinesisFirehoseDeliveryStreamIcebergConfigurationProcessingConfiguration;
+    /** */
+    readonly s3Configuration: KinesisFirehoseDeliveryStreamIcebergConfigurationS3Configuration;
+}
+export declare function kinesisFirehoseDeliveryStreamIcebergConfigurationToTerraform(struct?: KinesisFirehoseDeliveryStreamIcebergConfigurationOutputReference | KinesisFirehoseDeliveryStreamIcebergConfiguration): any;
+export declare function kinesisFirehoseDeliveryStreamIcebergConfigurationToHclTerraform(struct?: KinesisFirehoseDeliveryStreamIcebergConfigurationOutputReference | KinesisFirehoseDeliveryStreamIcebergConfiguration): any;
+export declare class KinesisFirehoseDeliveryStreamIcebergConfigurationOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamIcebergConfiguration | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamIcebergConfiguration | undefined);
+    private _bufferingInterval?;
+    get bufferingInterval(): number;
+    set bufferingInterval(value: number);
+    resetBufferingInterval(): void;
+    get bufferingIntervalInput(): number | undefined;
+    private _bufferingSize?;
+    get bufferingSize(): number;
+    set bufferingSize(value: number);
+    resetBufferingSize(): void;
+    get bufferingSizeInput(): number | undefined;
+    private _catalogArn?;
+    get catalogArn(): string;
+    set catalogArn(value: string);
+    get catalogArnInput(): string | undefined;
+    private _retryDuration?;
+    get retryDuration(): number;
+    set retryDuration(value: number);
+    resetRetryDuration(): void;
+    get retryDurationInput(): number | undefined;
+    private _roleArn?;
+    get roleArn(): string;
+    set roleArn(value: string);
+    get roleArnInput(): string | undefined;
+    private _s3BackupMode?;
+    get s3BackupMode(): string;
+    set s3BackupMode(value: string);
+    resetS3BackupMode(): void;
+    get s3BackupModeInput(): string | undefined;
+    private _cloudwatchLoggingOptions;
+    get cloudwatchLoggingOptions(): KinesisFirehoseDeliveryStreamIcebergConfigurationCloudwatchLoggingOptionsOutputReference;
+    putCloudwatchLoggingOptions(value: KinesisFirehoseDeliveryStreamIcebergConfigurationCloudwatchLoggingOptions): void;
+    resetCloudwatchLoggingOptions(): void;
+    get cloudwatchLoggingOptionsInput(): KinesisFirehoseDeliveryStreamIcebergConfigurationCloudwatchLoggingOptions | undefined;
+    private _destinationTableConfiguration;
+    get destinationTableConfiguration(): KinesisFirehoseDeliveryStreamIcebergConfigurationDestinationTableConfigurationList;
+    putDestinationTableConfiguration(value: KinesisFirehoseDeliveryStreamIcebergConfigurationDestinationTableConfiguration[] | cdktf.IResolvable): void;
+    resetDestinationTableConfiguration(): void;
+    get destinationTableConfigurationInput(): cdktf.IResolvable | KinesisFirehoseDeliveryStreamIcebergConfigurationDestinationTableConfiguration[] | undefined;
+    private _processingConfiguration;
+    get processingConfiguration(): KinesisFirehoseDeliveryStreamIcebergConfigurationProcessingConfigurationOutputReference;
+    putProcessingConfiguration(value: KinesisFirehoseDeliveryStreamIcebergConfigurationProcessingConfiguration): void;
+    resetProcessingConfiguration(): void;
+    get processingConfigurationInput(): KinesisFirehoseDeliveryStreamIcebergConfigurationProcessingConfiguration | undefined;
+    private _s3Configuration;
+    get s3Configuration(): KinesisFirehoseDeliveryStreamIcebergConfigurationS3ConfigurationOutputReference;
+    putS3Configuration(value: KinesisFirehoseDeliveryStreamIcebergConfigurationS3Configuration): void;
+    get s3ConfigurationInput(): KinesisFirehoseDeliveryStreamIcebergConfigurationS3Configuration | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamKinesisSourceConfiguration {
+    /** (Required) The kinesis stream used as the source of the firehose delivery stream. */
+    readonly kinesisStreamArn: string;
+    /** (Required) The ARN of the role that provides access to the source Kinesis stream. */
+    readonly roleArn: string;
+}
+export declare function kinesisFirehoseDeliveryStreamKinesisSourceConfigurationToTerraform(struct?: KinesisFirehoseDeliveryStreamKinesisSourceConfigurationOutputReference | KinesisFirehoseDeliveryStreamKinesisSourceConfiguration): any;
+export declare function kinesisFirehoseDeliveryStreamKinesisSourceConfigurationToHclTerraform(struct?: KinesisFirehoseDeliveryStreamKinesisSourceConfigurationOutputReference | KinesisFirehoseDeliveryStreamKinesisSourceConfiguration): any;
+export declare class KinesisFirehoseDeliveryStreamKinesisSourceConfigurationOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamKinesisSourceConfiguration | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamKinesisSourceConfiguration | undefined);
+    private _kinesisStreamArn?;
+    get kinesisStreamArn(): string;
+    set kinesisStreamArn(value: string);
+    get kinesisStreamArnInput(): string | undefined;
+    private _roleArn?;
+    get roleArn(): string;
+    set roleArn(value: string);
+    get roleArnInput(): string | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamMskSourceConfigurationAuthenticationConfiguration {
+    /** (Required) The type of connectivity used to access the Amazon MSK cluster. Valid values: `PUBLIC`, `PRIVATE`. */
+    readonly connectivity: string;
+    /** (Required) The ARN of the role used to access the Amazon MSK cluster. */
+    readonly roleArn: string;
+}
+export declare function kinesisFirehoseDeliveryStreamMskSourceConfigurationAuthenticationConfigurationToTerraform(struct?: KinesisFirehoseDeliveryStreamMskSourceConfigurationAuthenticationConfigurationOutputReference | KinesisFirehoseDeliveryStreamMskSourceConfigurationAuthenticationConfiguration): any;
+export declare function kinesisFirehoseDeliveryStreamMskSourceConfigurationAuthenticationConfigurationToHclTerraform(struct?: KinesisFirehoseDeliveryStreamMskSourceConfigurationAuthenticationConfigurationOutputReference | KinesisFirehoseDeliveryStreamMskSourceConfigurationAuthenticationConfiguration): any;
+export declare class KinesisFirehoseDeliveryStreamMskSourceConfigurationAuthenticationConfigurationOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamMskSourceConfigurationAuthenticationConfiguration | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamMskSourceConfigurationAuthenticationConfiguration | undefined);
+    private _connectivity?;
+    get connectivity(): string;
+    set connectivity(value: string);
+    get connectivityInput(): string | undefined;
+    private _roleArn?;
+    get roleArn(): string;
+    set roleArn(value: string);
+    get roleArnInput(): string | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamMskSourceConfiguration {
+    /** (Required) The ARN of the Amazon MSK cluster. */
+    readonly mskClusterArn: string;
+    /** (Optional) The start date and time in UTC for the offset position within your MSK topic from where Firehose begins to read. By default, this is set to timestamp when Firehose becomes Active. If you want to create a Firehose stream with Earliest start position set the `readFromTimestamp` parameter to Epoch (1970-01-01T00:00:00Z). */
+    readonly readFromTimestamp?: string;
+    /** (Required) The topic name within the Amazon MSK cluster. */
+    readonly topicName: string;
+    /** */
+    readonly authenticationConfiguration: KinesisFirehoseDeliveryStreamMskSourceConfigurationAuthenticationConfiguration;
+}
+export declare function kinesisFirehoseDeliveryStreamMskSourceConfigurationToTerraform(struct?: KinesisFirehoseDeliveryStreamMskSourceConfigurationOutputReference | KinesisFirehoseDeliveryStreamMskSourceConfiguration): any;
+export declare function kinesisFirehoseDeliveryStreamMskSourceConfigurationToHclTerraform(struct?: KinesisFirehoseDeliveryStreamMskSourceConfigurationOutputReference | KinesisFirehoseDeliveryStreamMskSourceConfiguration): any;
+export declare class KinesisFirehoseDeliveryStreamMskSourceConfigurationOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamMskSourceConfiguration | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamMskSourceConfiguration | undefined);
+    private _mskClusterArn?;
+    get mskClusterArn(): string;
+    set mskClusterArn(value: string);
+    get mskClusterArnInput(): string | undefined;
+    private _readFromTimestamp?;
+    get readFromTimestamp(): string;
+    set readFromTimestamp(value: string);
+    resetReadFromTimestamp(): void;
+    get readFromTimestampInput(): string | undefined;
+    private _topicName?;
+    get topicName(): string;
+    set topicName(value: string);
+    get topicNameInput(): string | undefined;
+    private _authenticationConfiguration;
+    get authenticationConfiguration(): KinesisFirehoseDeliveryStreamMskSourceConfigurationAuthenticationConfigurationOutputReference;
+    putAuthenticationConfiguration(value: KinesisFirehoseDeliveryStreamMskSourceConfigurationAuthenticationConfiguration): void;
+    get authenticationConfigurationInput(): KinesisFirehoseDeliveryStreamMskSourceConfigurationAuthenticationConfiguration | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamOpensearchConfigurationCloudwatchLoggingOptions {
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#enabled KinesisFirehoseDeliveryStream#enabled}
+    */
+    readonly enabled?: boolean | cdktf.IResolvable;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#log_group_name KinesisFirehoseDeliveryStream#log_group_name}
+    */
+    readonly logGroupName?: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#log_stream_name KinesisFirehoseDeliveryStream#log_stream_name}
+    */
+    readonly logStreamName?: string;
+}
+export declare function kinesisFirehoseDeliveryStreamOpensearchConfigurationCloudwatchLoggingOptionsToTerraform(struct?: KinesisFirehoseDeliveryStreamOpensearchConfigurationCloudwatchLoggingOptionsOutputReference | KinesisFirehoseDeliveryStreamOpensearchConfigurationCloudwatchLoggingOptions): any;
+export declare function kinesisFirehoseDeliveryStreamOpensearchConfigurationCloudwatchLoggingOptionsToHclTerraform(struct?: KinesisFirehoseDeliveryStreamOpensearchConfigurationCloudwatchLoggingOptionsOutputReference | KinesisFirehoseDeliveryStreamOpensearchConfigurationCloudwatchLoggingOptions): any;
+export declare class KinesisFirehoseDeliveryStreamOpensearchConfigurationCloudwatchLoggingOptionsOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamOpensearchConfigurationCloudwatchLoggingOptions | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamOpensearchConfigurationCloudwatchLoggingOptions | undefined);
+    private _enabled?;
+    get enabled(): boolean | cdktf.IResolvable;
+    set enabled(value: boolean | cdktf.IResolvable);
+    resetEnabled(): void;
+    get enabledInput(): boolean | cdktf.IResolvable | undefined;
+    private _logGroupName?;
+    get logGroupName(): string;
+    set logGroupName(value: string);
+    resetLogGroupName(): void;
+    get logGroupNameInput(): string | undefined;
+    private _logStreamName?;
+    get logStreamName(): string;
+    set logStreamName(value: string);
+    resetLogStreamName(): void;
+    get logStreamNameInput(): string | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamOpensearchConfigurationDocumentIdOptions {
+    /** (Required) The method for setting up document ID. Valid values: `FIREHOSE_DEFAULT`, `NO_DOCUMENT_ID`. */
+    readonly defaultDocumentIdFormat: string;
+}
+export declare function kinesisFirehoseDeliveryStreamOpensearchConfigurationDocumentIdOptionsToTerraform(struct?: KinesisFirehoseDeliveryStreamOpensearchConfigurationDocumentIdOptionsOutputReference | KinesisFirehoseDeliveryStreamOpensearchConfigurationDocumentIdOptions): any;
+export declare function kinesisFirehoseDeliveryStreamOpensearchConfigurationDocumentIdOptionsToHclTerraform(struct?: KinesisFirehoseDeliveryStreamOpensearchConfigurationDocumentIdOptionsOutputReference | KinesisFirehoseDeliveryStreamOpensearchConfigurationDocumentIdOptions): any;
+export declare class KinesisFirehoseDeliveryStreamOpensearchConfigurationDocumentIdOptionsOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamOpensearchConfigurationDocumentIdOptions | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamOpensearchConfigurationDocumentIdOptions | undefined);
+    private _defaultDocumentIdFormat?;
+    get defaultDocumentIdFormat(): string;
+    set defaultDocumentIdFormat(value: string);
+    get defaultDocumentIdFormatInput(): string | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamOpensearchConfigurationProcessingConfigurationProcessorsParameters {
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#parameter_name KinesisFirehoseDeliveryStream#parameter_name}
+    */
+    readonly parameterName: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#parameter_value KinesisFirehoseDeliveryStream#parameter_value}
+    */
+    readonly parameterValue: string;
+}
+export declare function kinesisFirehoseDeliveryStreamOpensearchConfigurationProcessingConfigurationProcessorsParametersToTerraform(struct?: KinesisFirehoseDeliveryStreamOpensearchConfigurationProcessingConfigurationProcessorsParameters | cdktf.IResolvable): any;
+export declare function kinesisFirehoseDeliveryStreamOpensearchConfigurationProcessingConfigurationProcessorsParametersToHclTerraform(struct?: KinesisFirehoseDeliveryStreamOpensearchConfigurationProcessingConfigurationProcessorsParameters | cdktf.IResolvable): any;
+export declare class KinesisFirehoseDeliveryStreamOpensearchConfigurationProcessingConfigurationProcessorsParametersOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    private resolvableValue?;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    * @param complexObjectIndex the index of this item in the list
+    * @param complexObjectIsFromSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string, complexObjectIndex: number, complexObjectIsFromSet: boolean);
+    get internalValue(): KinesisFirehoseDeliveryStreamOpensearchConfigurationProcessingConfigurationProcessorsParameters | cdktf.IResolvable | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamOpensearchConfigurationProcessingConfigurationProcessorsParameters | cdktf.IResolvable | undefined);
+    private _parameterName?;
+    get parameterName(): string;
+    set parameterName(value: string);
+    get parameterNameInput(): string | undefined;
+    private _parameterValue?;
+    get parameterValue(): string;
+    set parameterValue(value: string);
+    get parameterValueInput(): string | undefined;
+}
+export declare class KinesisFirehoseDeliveryStreamOpensearchConfigurationProcessingConfigurationProcessorsParametersList extends cdktf.ComplexList {
+    protected terraformResource: cdktf.IInterpolatingParent;
+    protected terraformAttribute: string;
+    protected wrapsSet: boolean;
+    internalValue?: KinesisFirehoseDeliveryStreamOpensearchConfigurationProcessingConfigurationProcessorsParameters[] | cdktf.IResolvable;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    * @param wrapsSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string, wrapsSet: boolean);
+    /**
+    * @param index the index of the item to return
+    */
+    get(index: number): KinesisFirehoseDeliveryStreamOpensearchConfigurationProcessingConfigurationProcessorsParametersOutputReference;
+}
+export interface KinesisFirehoseDeliveryStreamOpensearchConfigurationProcessingConfigurationProcessors {
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#type KinesisFirehoseDeliveryStream#type}
+    */
+    readonly type: string;
+    /**
+    * parameters block
+    *
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#parameters KinesisFirehoseDeliveryStream#parameters}
+    */
+    readonly parameters?: KinesisFirehoseDeliveryStreamOpensearchConfigurationProcessingConfigurationProcessorsParameters[] | cdktf.IResolvable;
+}
+export declare function kinesisFirehoseDeliveryStreamOpensearchConfigurationProcessingConfigurationProcessorsToTerraform(struct?: KinesisFirehoseDeliveryStreamOpensearchConfigurationProcessingConfigurationProcessors | cdktf.IResolvable): any;
+export declare function kinesisFirehoseDeliveryStreamOpensearchConfigurationProcessingConfigurationProcessorsToHclTerraform(struct?: KinesisFirehoseDeliveryStreamOpensearchConfigurationProcessingConfigurationProcessors | cdktf.IResolvable): any;
+export declare class KinesisFirehoseDeliveryStreamOpensearchConfigurationProcessingConfigurationProcessorsOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    private resolvableValue?;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    * @param complexObjectIndex the index of this item in the list
+    * @param complexObjectIsFromSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string, complexObjectIndex: number, complexObjectIsFromSet: boolean);
+    get internalValue(): KinesisFirehoseDeliveryStreamOpensearchConfigurationProcessingConfigurationProcessors | cdktf.IResolvable | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamOpensearchConfigurationProcessingConfigurationProcessors | cdktf.IResolvable | undefined);
+    private _type?;
+    get type(): string;
+    set type(value: string);
+    get typeInput(): string | undefined;
+    private _parameters;
+    get parameters(): KinesisFirehoseDeliveryStreamOpensearchConfigurationProcessingConfigurationProcessorsParametersList;
+    putParameters(value: KinesisFirehoseDeliveryStreamOpensearchConfigurationProcessingConfigurationProcessorsParameters[] | cdktf.IResolvable): void;
+    resetParameters(): void;
+    get parametersInput(): cdktf.IResolvable | KinesisFirehoseDeliveryStreamOpensearchConfigurationProcessingConfigurationProcessorsParameters[] | undefined;
+}
+export declare class KinesisFirehoseDeliveryStreamOpensearchConfigurationProcessingConfigurationProcessorsList extends cdktf.ComplexList {
+    protected terraformResource: cdktf.IInterpolatingParent;
+    protected terraformAttribute: string;
+    protected wrapsSet: boolean;
+    internalValue?: KinesisFirehoseDeliveryStreamOpensearchConfigurationProcessingConfigurationProcessors[] | cdktf.IResolvable;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    * @param wrapsSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string, wrapsSet: boolean);
+    /**
+    * @param index the index of the item to return
+    */
+    get(index: number): KinesisFirehoseDeliveryStreamOpensearchConfigurationProcessingConfigurationProcessorsOutputReference;
+}
+export interface KinesisFirehoseDeliveryStreamOpensearchConfigurationProcessingConfiguration {
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#enabled KinesisFirehoseDeliveryStream#enabled}
+    */
+    readonly enabled?: boolean | cdktf.IResolvable;
+    /**
+    * processors block
+    *
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#processors KinesisFirehoseDeliveryStream#processors}
+    */
+    readonly processors?: KinesisFirehoseDeliveryStreamOpensearchConfigurationProcessingConfigurationProcessors[] | cdktf.IResolvable;
+}
+export declare function kinesisFirehoseDeliveryStreamOpensearchConfigurationProcessingConfigurationToTerraform(struct?: KinesisFirehoseDeliveryStreamOpensearchConfigurationProcessingConfigurationOutputReference | KinesisFirehoseDeliveryStreamOpensearchConfigurationProcessingConfiguration): any;
+export declare function kinesisFirehoseDeliveryStreamOpensearchConfigurationProcessingConfigurationToHclTerraform(struct?: KinesisFirehoseDeliveryStreamOpensearchConfigurationProcessingConfigurationOutputReference | KinesisFirehoseDeliveryStreamOpensearchConfigurationProcessingConfiguration): any;
+export declare class KinesisFirehoseDeliveryStreamOpensearchConfigurationProcessingConfigurationOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamOpensearchConfigurationProcessingConfiguration | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamOpensearchConfigurationProcessingConfiguration | undefined);
+    private _enabled?;
+    get enabled(): boolean | cdktf.IResolvable;
+    set enabled(value: boolean | cdktf.IResolvable);
+    resetEnabled(): void;
+    get enabledInput(): boolean | cdktf.IResolvable | undefined;
+    private _processors;
+    get processors(): KinesisFirehoseDeliveryStreamOpensearchConfigurationProcessingConfigurationProcessorsList;
+    putProcessors(value: KinesisFirehoseDeliveryStreamOpensearchConfigurationProcessingConfigurationProcessors[] | cdktf.IResolvable): void;
+    resetProcessors(): void;
+    get processorsInput(): cdktf.IResolvable | KinesisFirehoseDeliveryStreamOpensearchConfigurationProcessingConfigurationProcessors[] | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamOpensearchConfigurationS3ConfigurationCloudwatchLoggingOptions {
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#enabled KinesisFirehoseDeliveryStream#enabled}
+    */
+    readonly enabled?: boolean | cdktf.IResolvable;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#log_group_name KinesisFirehoseDeliveryStream#log_group_name}
+    */
+    readonly logGroupName?: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#log_stream_name KinesisFirehoseDeliveryStream#log_stream_name}
+    */
+    readonly logStreamName?: string;
+}
+export declare function kinesisFirehoseDeliveryStreamOpensearchConfigurationS3ConfigurationCloudwatchLoggingOptionsToTerraform(struct?: KinesisFirehoseDeliveryStreamOpensearchConfigurationS3ConfigurationCloudwatchLoggingOptionsOutputReference | KinesisFirehoseDeliveryStreamOpensearchConfigurationS3ConfigurationCloudwatchLoggingOptions): any;
+export declare function kinesisFirehoseDeliveryStreamOpensearchConfigurationS3ConfigurationCloudwatchLoggingOptionsToHclTerraform(struct?: KinesisFirehoseDeliveryStreamOpensearchConfigurationS3ConfigurationCloudwatchLoggingOptionsOutputReference | KinesisFirehoseDeliveryStreamOpensearchConfigurationS3ConfigurationCloudwatchLoggingOptions): any;
+export declare class KinesisFirehoseDeliveryStreamOpensearchConfigurationS3ConfigurationCloudwatchLoggingOptionsOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamOpensearchConfigurationS3ConfigurationCloudwatchLoggingOptions | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamOpensearchConfigurationS3ConfigurationCloudwatchLoggingOptions | undefined);
+    private _enabled?;
+    get enabled(): boolean | cdktf.IResolvable;
+    set enabled(value: boolean | cdktf.IResolvable);
+    resetEnabled(): void;
+    get enabledInput(): boolean | cdktf.IResolvable | undefined;
+    private _logGroupName?;
+    get logGroupName(): string;
+    set logGroupName(value: string);
+    resetLogGroupName(): void;
+    get logGroupNameInput(): string | undefined;
+    private _logStreamName?;
+    get logStreamName(): string;
+    set logStreamName(value: string);
+    resetLogStreamName(): void;
+    get logStreamNameInput(): string | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamOpensearchConfigurationS3Configuration {
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#bucket_arn KinesisFirehoseDeliveryStream#bucket_arn}
+    */
+    readonly bucketArn: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#buffering_interval KinesisFirehoseDeliveryStream#buffering_interval}
+    */
+    readonly bufferingInterval?: number;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#buffering_size KinesisFirehoseDeliveryStream#buffering_size}
+    */
+    readonly bufferingSize?: number;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#compression_format KinesisFirehoseDeliveryStream#compression_format}
+    */
+    readonly compressionFormat?: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#error_output_prefix KinesisFirehoseDeliveryStream#error_output_prefix}
+    */
+    readonly errorOutputPrefix?: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#kms_key_arn KinesisFirehoseDeliveryStream#kms_key_arn}
+    */
+    readonly kmsKeyArn?: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#prefix KinesisFirehoseDeliveryStream#prefix}
+    */
+    readonly prefix?: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#role_arn KinesisFirehoseDeliveryStream#role_arn}
+    */
+    readonly roleArn: string;
+    /**
+    * cloudwatch_logging_options block
+    *
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#cloudwatch_logging_options KinesisFirehoseDeliveryStream#cloudwatch_logging_options}
+    */
+    readonly cloudwatchLoggingOptions?: KinesisFirehoseDeliveryStreamOpensearchConfigurationS3ConfigurationCloudwatchLoggingOptions;
+}
+export declare function kinesisFirehoseDeliveryStreamOpensearchConfigurationS3ConfigurationToTerraform(struct?: KinesisFirehoseDeliveryStreamOpensearchConfigurationS3ConfigurationOutputReference | KinesisFirehoseDeliveryStreamOpensearchConfigurationS3Configuration): any;
+export declare function kinesisFirehoseDeliveryStreamOpensearchConfigurationS3ConfigurationToHclTerraform(struct?: KinesisFirehoseDeliveryStreamOpensearchConfigurationS3ConfigurationOutputReference | KinesisFirehoseDeliveryStreamOpensearchConfigurationS3Configuration): any;
+export declare class KinesisFirehoseDeliveryStreamOpensearchConfigurationS3ConfigurationOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamOpensearchConfigurationS3Configuration | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamOpensearchConfigurationS3Configuration | undefined);
+    private _bucketArn?;
+    get bucketArn(): string;
+    set bucketArn(value: string);
+    get bucketArnInput(): string | undefined;
+    private _bufferingInterval?;
+    get bufferingInterval(): number;
+    set bufferingInterval(value: number);
+    resetBufferingInterval(): void;
+    get bufferingIntervalInput(): number | undefined;
+    private _bufferingSize?;
+    get bufferingSize(): number;
+    set bufferingSize(value: number);
+    resetBufferingSize(): void;
+    get bufferingSizeInput(): number | undefined;
+    private _compressionFormat?;
+    get compressionFormat(): string;
+    set compressionFormat(value: string);
+    resetCompressionFormat(): void;
+    get compressionFormatInput(): string | undefined;
+    private _errorOutputPrefix?;
+    get errorOutputPrefix(): string;
+    set errorOutputPrefix(value: string);
+    resetErrorOutputPrefix(): void;
+    get errorOutputPrefixInput(): string | undefined;
+    private _kmsKeyArn?;
+    get kmsKeyArn(): string;
+    set kmsKeyArn(value: string);
+    resetKmsKeyArn(): void;
+    get kmsKeyArnInput(): string | undefined;
+    private _prefix?;
+    get prefix(): string;
+    set prefix(value: string);
+    resetPrefix(): void;
+    get prefixInput(): string | undefined;
+    private _roleArn?;
+    get roleArn(): string;
+    set roleArn(value: string);
+    get roleArnInput(): string | undefined;
+    private _cloudwatchLoggingOptions;
+    get cloudwatchLoggingOptions(): KinesisFirehoseDeliveryStreamOpensearchConfigurationS3ConfigurationCloudwatchLoggingOptionsOutputReference;
+    putCloudwatchLoggingOptions(value: KinesisFirehoseDeliveryStreamOpensearchConfigurationS3ConfigurationCloudwatchLoggingOptions): void;
+    resetCloudwatchLoggingOptions(): void;
+    get cloudwatchLoggingOptionsInput(): KinesisFirehoseDeliveryStreamOpensearchConfigurationS3ConfigurationCloudwatchLoggingOptions | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamOpensearchConfigurationVpcConfig {
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#role_arn KinesisFirehoseDeliveryStream#role_arn}
+    */
+    readonly roleArn: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#security_group_ids KinesisFirehoseDeliveryStream#security_group_ids}
+    */
+    readonly securityGroupIds: string[];
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#subnet_ids KinesisFirehoseDeliveryStream#subnet_ids}
+    */
+    readonly subnetIds: string[];
+}
+export declare function kinesisFirehoseDeliveryStreamOpensearchConfigurationVpcConfigToTerraform(struct?: KinesisFirehoseDeliveryStreamOpensearchConfigurationVpcConfigOutputReference | KinesisFirehoseDeliveryStreamOpensearchConfigurationVpcConfig): any;
+export declare function kinesisFirehoseDeliveryStreamOpensearchConfigurationVpcConfigToHclTerraform(struct?: KinesisFirehoseDeliveryStreamOpensearchConfigurationVpcConfigOutputReference | KinesisFirehoseDeliveryStreamOpensearchConfigurationVpcConfig): any;
+export declare class KinesisFirehoseDeliveryStreamOpensearchConfigurationVpcConfigOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamOpensearchConfigurationVpcConfig | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamOpensearchConfigurationVpcConfig | undefined);
+    private _roleArn?;
+    get roleArn(): string;
+    set roleArn(value: string);
+    get roleArnInput(): string | undefined;
+    private _securityGroupIds?;
+    get securityGroupIds(): string[];
+    set securityGroupIds(value: string[]);
+    get securityGroupIdsInput(): string[] | undefined;
+    private _subnetIds?;
+    get subnetIds(): string[];
+    set subnetIds(value: string[]);
+    get subnetIdsInput(): string[] | undefined;
+    get vpcId(): string;
+}
+export interface KinesisFirehoseDeliveryStreamOpensearchConfiguration {
+    /** (Optional) Buffer incoming data for the specified period of time, in seconds between 0 to 900, before delivering it to the destination.  The default value is 300s. */
+    readonly bufferingInterval?: number;
+    /** (Optional) Buffer incoming data to the specified size, in MBs between 1 to 100, before delivering it to the destination.  The default value is 5MB. */
+    readonly bufferingSize?: number;
+    /** (Optional) The endpoint to use when communicating with the cluster. Conflicts with `domainArn`. */
+    readonly clusterEndpoint?: string;
+    /** (Optional) The ARN of the Amazon ES domain.  The pattern needs to be `arn:.*`.  Conflicts with `clusterEndpoint`. */
+    readonly domainArn?: string;
+    /** (Required) The OpenSearch index name. */
+    readonly indexName: string;
+    /** (Optional) The OpenSearch index rotation period.  Index rotation appends a timestamp to the IndexName to facilitate expiration of old data.  Valid values are `NoRotation`, `OneHour`, `OneDay`, `OneWeek`, and `OneMonth`.  The default value is `OneDay`. */
+    readonly indexRotationPeriod?: string;
+    /** (Optional) After an initial failure to deliver to Amazon OpenSearch, the total amount of time, in seconds between 0 to 7200, during which Firehose re-attempts delivery (including the first attempt).  After this time has elapsed, the failed documents are written to Amazon S3.  The default value is 300s.  There will be no retry if the value is 0. */
+    readonly retryDuration?: number;
+    /** (Required) The ARN of the IAM role to be assumed by Firehose for calling the Amazon ES Configuration API and for indexing documents.  The IAM role must have permission for `DescribeDomain`, `DescribeDomains`, and `DescribeDomainConfig`.  The pattern needs to be `arn:.*`. */
+    readonly roleArn: string;
+    /** (Optional) Defines how documents should be delivered to Amazon S3.  Valid values are `FailedDocumentsOnly` and `AllDocuments`.  Default value is `FailedDocumentsOnly`. */
+    readonly s3BackupMode?: string;
+    /** (Optional) The Elasticsearch type name with maximum length of 100 characters. Types are deprecated in OpenSearch_1.1. TypeName must be empty. */
+    readonly typeName?: string;
+    /** */
+    readonly cloudwatchLoggingOptions?: KinesisFirehoseDeliveryStreamOpensearchConfigurationCloudwatchLoggingOptions;
+    /** */
+    readonly documentIdOptions?: KinesisFirehoseDeliveryStreamOpensearchConfigurationDocumentIdOptions;
+    /** */
+    readonly processingConfiguration?: KinesisFirehoseDeliveryStreamOpensearchConfigurationProcessingConfiguration;
+    /** */
+    readonly s3Configuration: KinesisFirehoseDeliveryStreamOpensearchConfigurationS3Configuration;
+    /** */
+    readonly vpcConfig?: KinesisFirehoseDeliveryStreamOpensearchConfigurationVpcConfig;
+}
+export declare function kinesisFirehoseDeliveryStreamOpensearchConfigurationToTerraform(struct?: KinesisFirehoseDeliveryStreamOpensearchConfigurationOutputReference | KinesisFirehoseDeliveryStreamOpensearchConfiguration): any;
+export declare function kinesisFirehoseDeliveryStreamOpensearchConfigurationToHclTerraform(struct?: KinesisFirehoseDeliveryStreamOpensearchConfigurationOutputReference | KinesisFirehoseDeliveryStreamOpensearchConfiguration): any;
+export declare class KinesisFirehoseDeliveryStreamOpensearchConfigurationOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamOpensearchConfiguration | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamOpensearchConfiguration | undefined);
+    private _bufferingInterval?;
+    get bufferingInterval(): number;
+    set bufferingInterval(value: number);
+    resetBufferingInterval(): void;
+    get bufferingIntervalInput(): number | undefined;
+    private _bufferingSize?;
+    get bufferingSize(): number;
+    set bufferingSize(value: number);
+    resetBufferingSize(): void;
+    get bufferingSizeInput(): number | undefined;
+    private _clusterEndpoint?;
+    get clusterEndpoint(): string;
+    set clusterEndpoint(value: string);
+    resetClusterEndpoint(): void;
+    get clusterEndpointInput(): string | undefined;
+    private _domainArn?;
+    get domainArn(): string;
+    set domainArn(value: string);
+    resetDomainArn(): void;
+    get domainArnInput(): string | undefined;
+    private _indexName?;
+    get indexName(): string;
+    set indexName(value: string);
+    get indexNameInput(): string | undefined;
+    private _indexRotationPeriod?;
+    get indexRotationPeriod(): string;
+    set indexRotationPeriod(value: string);
+    resetIndexRotationPeriod(): void;
+    get indexRotationPeriodInput(): string | undefined;
+    private _retryDuration?;
+    get retryDuration(): number;
+    set retryDuration(value: number);
+    resetRetryDuration(): void;
+    get retryDurationInput(): number | undefined;
+    private _roleArn?;
+    get roleArn(): string;
+    set roleArn(value: string);
+    get roleArnInput(): string | undefined;
+    private _s3BackupMode?;
+    get s3BackupMode(): string;
+    set s3BackupMode(value: string);
+    resetS3BackupMode(): void;
+    get s3BackupModeInput(): string | undefined;
+    private _typeName?;
+    get typeName(): string;
+    set typeName(value: string);
+    resetTypeName(): void;
+    get typeNameInput(): string | undefined;
+    private _cloudwatchLoggingOptions;
+    get cloudwatchLoggingOptions(): KinesisFirehoseDeliveryStreamOpensearchConfigurationCloudwatchLoggingOptionsOutputReference;
+    putCloudwatchLoggingOptions(value: KinesisFirehoseDeliveryStreamOpensearchConfigurationCloudwatchLoggingOptions): void;
+    resetCloudwatchLoggingOptions(): void;
+    get cloudwatchLoggingOptionsInput(): KinesisFirehoseDeliveryStreamOpensearchConfigurationCloudwatchLoggingOptions | undefined;
+    private _documentIdOptions;
+    get documentIdOptions(): KinesisFirehoseDeliveryStreamOpensearchConfigurationDocumentIdOptionsOutputReference;
+    putDocumentIdOptions(value: KinesisFirehoseDeliveryStreamOpensearchConfigurationDocumentIdOptions): void;
+    resetDocumentIdOptions(): void;
+    get documentIdOptionsInput(): KinesisFirehoseDeliveryStreamOpensearchConfigurationDocumentIdOptions | undefined;
+    private _processingConfiguration;
+    get processingConfiguration(): KinesisFirehoseDeliveryStreamOpensearchConfigurationProcessingConfigurationOutputReference;
+    putProcessingConfiguration(value: KinesisFirehoseDeliveryStreamOpensearchConfigurationProcessingConfiguration): void;
+    resetProcessingConfiguration(): void;
+    get processingConfigurationInput(): KinesisFirehoseDeliveryStreamOpensearchConfigurationProcessingConfiguration | undefined;
+    private _s3Configuration;
+    get s3Configuration(): KinesisFirehoseDeliveryStreamOpensearchConfigurationS3ConfigurationOutputReference;
+    putS3Configuration(value: KinesisFirehoseDeliveryStreamOpensearchConfigurationS3Configuration): void;
+    get s3ConfigurationInput(): KinesisFirehoseDeliveryStreamOpensearchConfigurationS3Configuration | undefined;
+    private _vpcConfig;
+    get vpcConfig(): KinesisFirehoseDeliveryStreamOpensearchConfigurationVpcConfigOutputReference;
+    putVpcConfig(value: KinesisFirehoseDeliveryStreamOpensearchConfigurationVpcConfig): void;
+    resetVpcConfig(): void;
+    get vpcConfigInput(): KinesisFirehoseDeliveryStreamOpensearchConfigurationVpcConfig | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationCloudwatchLoggingOptions {
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#enabled KinesisFirehoseDeliveryStream#enabled}
+    */
+    readonly enabled?: boolean | cdktf.IResolvable;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#log_group_name KinesisFirehoseDeliveryStream#log_group_name}
+    */
+    readonly logGroupName?: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#log_stream_name KinesisFirehoseDeliveryStream#log_stream_name}
+    */
+    readonly logStreamName?: string;
+}
+export declare function kinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationCloudwatchLoggingOptionsToTerraform(struct?: KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationCloudwatchLoggingOptionsOutputReference | KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationCloudwatchLoggingOptions): any;
+export declare function kinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationCloudwatchLoggingOptionsToHclTerraform(struct?: KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationCloudwatchLoggingOptionsOutputReference | KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationCloudwatchLoggingOptions): any;
+export declare class KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationCloudwatchLoggingOptionsOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationCloudwatchLoggingOptions | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationCloudwatchLoggingOptions | undefined);
+    private _enabled?;
+    get enabled(): boolean | cdktf.IResolvable;
+    set enabled(value: boolean | cdktf.IResolvable);
+    resetEnabled(): void;
+    get enabledInput(): boolean | cdktf.IResolvable | undefined;
+    private _logGroupName?;
+    get logGroupName(): string;
+    set logGroupName(value: string);
+    resetLogGroupName(): void;
+    get logGroupNameInput(): string | undefined;
+    private _logStreamName?;
+    get logStreamName(): string;
+    set logStreamName(value: string);
+    resetLogStreamName(): void;
+    get logStreamNameInput(): string | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationProcessingConfigurationProcessorsParameters {
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#parameter_name KinesisFirehoseDeliveryStream#parameter_name}
+    */
+    readonly parameterName: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#parameter_value KinesisFirehoseDeliveryStream#parameter_value}
+    */
+    readonly parameterValue: string;
+}
+export declare function kinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationProcessingConfigurationProcessorsParametersToTerraform(struct?: KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationProcessingConfigurationProcessorsParameters | cdktf.IResolvable): any;
+export declare function kinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationProcessingConfigurationProcessorsParametersToHclTerraform(struct?: KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationProcessingConfigurationProcessorsParameters | cdktf.IResolvable): any;
+export declare class KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationProcessingConfigurationProcessorsParametersOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    private resolvableValue?;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    * @param complexObjectIndex the index of this item in the list
+    * @param complexObjectIsFromSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string, complexObjectIndex: number, complexObjectIsFromSet: boolean);
+    get internalValue(): KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationProcessingConfigurationProcessorsParameters | cdktf.IResolvable | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationProcessingConfigurationProcessorsParameters | cdktf.IResolvable | undefined);
+    private _parameterName?;
+    get parameterName(): string;
+    set parameterName(value: string);
+    get parameterNameInput(): string | undefined;
+    private _parameterValue?;
+    get parameterValue(): string;
+    set parameterValue(value: string);
+    get parameterValueInput(): string | undefined;
+}
+export declare class KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationProcessingConfigurationProcessorsParametersList extends cdktf.ComplexList {
+    protected terraformResource: cdktf.IInterpolatingParent;
+    protected terraformAttribute: string;
+    protected wrapsSet: boolean;
+    internalValue?: KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationProcessingConfigurationProcessorsParameters[] | cdktf.IResolvable;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    * @param wrapsSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string, wrapsSet: boolean);
+    /**
+    * @param index the index of the item to return
+    */
+    get(index: number): KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationProcessingConfigurationProcessorsParametersOutputReference;
+}
+export interface KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationProcessingConfigurationProcessors {
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#type KinesisFirehoseDeliveryStream#type}
+    */
+    readonly type: string;
+    /**
+    * parameters block
+    *
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#parameters KinesisFirehoseDeliveryStream#parameters}
+    */
+    readonly parameters?: KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationProcessingConfigurationProcessorsParameters[] | cdktf.IResolvable;
+}
+export declare function kinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationProcessingConfigurationProcessorsToTerraform(struct?: KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationProcessingConfigurationProcessors | cdktf.IResolvable): any;
+export declare function kinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationProcessingConfigurationProcessorsToHclTerraform(struct?: KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationProcessingConfigurationProcessors | cdktf.IResolvable): any;
+export declare class KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationProcessingConfigurationProcessorsOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    private resolvableValue?;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    * @param complexObjectIndex the index of this item in the list
+    * @param complexObjectIsFromSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string, complexObjectIndex: number, complexObjectIsFromSet: boolean);
+    get internalValue(): KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationProcessingConfigurationProcessors | cdktf.IResolvable | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationProcessingConfigurationProcessors | cdktf.IResolvable | undefined);
+    private _type?;
+    get type(): string;
+    set type(value: string);
+    get typeInput(): string | undefined;
+    private _parameters;
+    get parameters(): KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationProcessingConfigurationProcessorsParametersList;
+    putParameters(value: KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationProcessingConfigurationProcessorsParameters[] | cdktf.IResolvable): void;
+    resetParameters(): void;
+    get parametersInput(): cdktf.IResolvable | KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationProcessingConfigurationProcessorsParameters[] | undefined;
+}
+export declare class KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationProcessingConfigurationProcessorsList extends cdktf.ComplexList {
+    protected terraformResource: cdktf.IInterpolatingParent;
+    protected terraformAttribute: string;
+    protected wrapsSet: boolean;
+    internalValue?: KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationProcessingConfigurationProcessors[] | cdktf.IResolvable;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    * @param wrapsSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string, wrapsSet: boolean);
+    /**
+    * @param index the index of the item to return
+    */
+    get(index: number): KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationProcessingConfigurationProcessorsOutputReference;
+}
+export interface KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationProcessingConfiguration {
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#enabled KinesisFirehoseDeliveryStream#enabled}
+    */
+    readonly enabled?: boolean | cdktf.IResolvable;
+    /**
+    * processors block
+    *
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#processors KinesisFirehoseDeliveryStream#processors}
+    */
+    readonly processors?: KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationProcessingConfigurationProcessors[] | cdktf.IResolvable;
+}
+export declare function kinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationProcessingConfigurationToTerraform(struct?: KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationProcessingConfigurationOutputReference | KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationProcessingConfiguration): any;
+export declare function kinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationProcessingConfigurationToHclTerraform(struct?: KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationProcessingConfigurationOutputReference | KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationProcessingConfiguration): any;
+export declare class KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationProcessingConfigurationOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationProcessingConfiguration | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationProcessingConfiguration | undefined);
+    private _enabled?;
+    get enabled(): boolean | cdktf.IResolvable;
+    set enabled(value: boolean | cdktf.IResolvable);
+    resetEnabled(): void;
+    get enabledInput(): boolean | cdktf.IResolvable | undefined;
+    private _processors;
+    get processors(): KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationProcessingConfigurationProcessorsList;
+    putProcessors(value: KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationProcessingConfigurationProcessors[] | cdktf.IResolvable): void;
+    resetProcessors(): void;
+    get processorsInput(): cdktf.IResolvable | KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationProcessingConfigurationProcessors[] | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationS3ConfigurationCloudwatchLoggingOptions {
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#enabled KinesisFirehoseDeliveryStream#enabled}
+    */
+    readonly enabled?: boolean | cdktf.IResolvable;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#log_group_name KinesisFirehoseDeliveryStream#log_group_name}
+    */
+    readonly logGroupName?: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#log_stream_name KinesisFirehoseDeliveryStream#log_stream_name}
+    */
+    readonly logStreamName?: string;
+}
+export declare function kinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationS3ConfigurationCloudwatchLoggingOptionsToTerraform(struct?: KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationS3ConfigurationCloudwatchLoggingOptionsOutputReference | KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationS3ConfigurationCloudwatchLoggingOptions): any;
+export declare function kinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationS3ConfigurationCloudwatchLoggingOptionsToHclTerraform(struct?: KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationS3ConfigurationCloudwatchLoggingOptionsOutputReference | KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationS3ConfigurationCloudwatchLoggingOptions): any;
+export declare class KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationS3ConfigurationCloudwatchLoggingOptionsOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationS3ConfigurationCloudwatchLoggingOptions | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationS3ConfigurationCloudwatchLoggingOptions | undefined);
+    private _enabled?;
+    get enabled(): boolean | cdktf.IResolvable;
+    set enabled(value: boolean | cdktf.IResolvable);
+    resetEnabled(): void;
+    get enabledInput(): boolean | cdktf.IResolvable | undefined;
+    private _logGroupName?;
+    get logGroupName(): string;
+    set logGroupName(value: string);
+    resetLogGroupName(): void;
+    get logGroupNameInput(): string | undefined;
+    private _logStreamName?;
+    get logStreamName(): string;
+    set logStreamName(value: string);
+    resetLogStreamName(): void;
+    get logStreamNameInput(): string | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationS3Configuration {
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#bucket_arn KinesisFirehoseDeliveryStream#bucket_arn}
+    */
+    readonly bucketArn: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#buffering_interval KinesisFirehoseDeliveryStream#buffering_interval}
+    */
+    readonly bufferingInterval?: number;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#buffering_size KinesisFirehoseDeliveryStream#buffering_size}
+    */
+    readonly bufferingSize?: number;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#compression_format KinesisFirehoseDeliveryStream#compression_format}
+    */
+    readonly compressionFormat?: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#error_output_prefix KinesisFirehoseDeliveryStream#error_output_prefix}
+    */
+    readonly errorOutputPrefix?: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#kms_key_arn KinesisFirehoseDeliveryStream#kms_key_arn}
+    */
+    readonly kmsKeyArn?: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#prefix KinesisFirehoseDeliveryStream#prefix}
+    */
+    readonly prefix?: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#role_arn KinesisFirehoseDeliveryStream#role_arn}
+    */
+    readonly roleArn: string;
+    /**
+    * cloudwatch_logging_options block
+    *
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#cloudwatch_logging_options KinesisFirehoseDeliveryStream#cloudwatch_logging_options}
+    */
+    readonly cloudwatchLoggingOptions?: KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationS3ConfigurationCloudwatchLoggingOptions;
+}
+export declare function kinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationS3ConfigurationToTerraform(struct?: KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationS3ConfigurationOutputReference | KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationS3Configuration): any;
+export declare function kinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationS3ConfigurationToHclTerraform(struct?: KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationS3ConfigurationOutputReference | KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationS3Configuration): any;
+export declare class KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationS3ConfigurationOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationS3Configuration | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationS3Configuration | undefined);
+    private _bucketArn?;
+    get bucketArn(): string;
+    set bucketArn(value: string);
+    get bucketArnInput(): string | undefined;
+    private _bufferingInterval?;
+    get bufferingInterval(): number;
+    set bufferingInterval(value: number);
+    resetBufferingInterval(): void;
+    get bufferingIntervalInput(): number | undefined;
+    private _bufferingSize?;
+    get bufferingSize(): number;
+    set bufferingSize(value: number);
+    resetBufferingSize(): void;
+    get bufferingSizeInput(): number | undefined;
+    private _compressionFormat?;
+    get compressionFormat(): string;
+    set compressionFormat(value: string);
+    resetCompressionFormat(): void;
+    get compressionFormatInput(): string | undefined;
+    private _errorOutputPrefix?;
+    get errorOutputPrefix(): string;
+    set errorOutputPrefix(value: string);
+    resetErrorOutputPrefix(): void;
+    get errorOutputPrefixInput(): string | undefined;
+    private _kmsKeyArn?;
+    get kmsKeyArn(): string;
+    set kmsKeyArn(value: string);
+    resetKmsKeyArn(): void;
+    get kmsKeyArnInput(): string | undefined;
+    private _prefix?;
+    get prefix(): string;
+    set prefix(value: string);
+    resetPrefix(): void;
+    get prefixInput(): string | undefined;
+    private _roleArn?;
+    get roleArn(): string;
+    set roleArn(value: string);
+    get roleArnInput(): string | undefined;
+    private _cloudwatchLoggingOptions;
+    get cloudwatchLoggingOptions(): KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationS3ConfigurationCloudwatchLoggingOptionsOutputReference;
+    putCloudwatchLoggingOptions(value: KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationS3ConfigurationCloudwatchLoggingOptions): void;
+    resetCloudwatchLoggingOptions(): void;
+    get cloudwatchLoggingOptionsInput(): KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationS3ConfigurationCloudwatchLoggingOptions | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationVpcConfig {
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#role_arn KinesisFirehoseDeliveryStream#role_arn}
+    */
+    readonly roleArn: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#security_group_ids KinesisFirehoseDeliveryStream#security_group_ids}
+    */
+    readonly securityGroupIds: string[];
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#subnet_ids KinesisFirehoseDeliveryStream#subnet_ids}
+    */
+    readonly subnetIds: string[];
+}
+export declare function kinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationVpcConfigToTerraform(struct?: KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationVpcConfigOutputReference | KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationVpcConfig): any;
+export declare function kinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationVpcConfigToHclTerraform(struct?: KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationVpcConfigOutputReference | KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationVpcConfig): any;
+export declare class KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationVpcConfigOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationVpcConfig | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationVpcConfig | undefined);
+    private _roleArn?;
+    get roleArn(): string;
+    set roleArn(value: string);
+    get roleArnInput(): string | undefined;
+    private _securityGroupIds?;
+    get securityGroupIds(): string[];
+    set securityGroupIds(value: string[]);
+    get securityGroupIdsInput(): string[] | undefined;
+    private _subnetIds?;
+    get subnetIds(): string[];
+    set subnetIds(value: string[]);
+    get subnetIdsInput(): string[] | undefined;
+    get vpcId(): string;
+}
+export interface KinesisFirehoseDeliveryStreamOpensearchserverlessConfiguration {
+    /** (Optional) Buffer incoming data for the specified period of time, in seconds between 0 to 900, before delivering it to the destination.  The default value is 300s. */
+    readonly bufferingInterval?: number;
+    /** (Optional) Buffer incoming data to the specified size, in MBs between 1 to 100, before delivering it to the destination.  The default value is 5MB. */
+    readonly bufferingSize?: number;
+    /** (Required) The endpoint to use when communicating with the collection in the Serverless offering for Amazon OpenSearch Service. */
+    readonly collectionEndpoint: string;
+    /** (Required) The Serverless offering for Amazon OpenSearch Service index name. */
+    readonly indexName: string;
+    /** (Optional) After an initial failure to deliver to the Serverless offering for Amazon OpenSearch Service, the total amount of time, in seconds between 0 to 7200, during which Kinesis Data Firehose retries delivery (including the first attempt).  After this time has elapsed, the failed documents are written to Amazon S3.  The default value is 300s.  There will be no retry if the value is 0. */
+    readonly retryDuration?: number;
+    /** (Required) The Amazon Resource Name (ARN) of the IAM role to be assumed by Kinesis Data Firehose for calling the Serverless offering for Amazon OpenSearch Service Configuration API and for indexing documents.  The pattern needs to be `arn:.*`. */
+    readonly roleArn: string;
+    /** (Optional) Defines how documents should be delivered to Amazon S3.  Valid values are `FailedDocumentsOnly` and `AllDocuments`.  Default value is `FailedDocumentsOnly`. */
+    readonly s3BackupMode?: string;
+    /** */
+    readonly cloudwatchLoggingOptions?: KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationCloudwatchLoggingOptions;
+    /** */
+    readonly processingConfiguration?: KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationProcessingConfiguration;
+    /** */
+    readonly s3Configuration: KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationS3Configuration;
+    /** */
+    readonly vpcConfig?: KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationVpcConfig;
+}
+export declare function kinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationToTerraform(struct?: KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationOutputReference | KinesisFirehoseDeliveryStreamOpensearchserverlessConfiguration): any;
+export declare function kinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationToHclTerraform(struct?: KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationOutputReference | KinesisFirehoseDeliveryStreamOpensearchserverlessConfiguration): any;
+export declare class KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamOpensearchserverlessConfiguration | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamOpensearchserverlessConfiguration | undefined);
+    private _bufferingInterval?;
+    get bufferingInterval(): number;
+    set bufferingInterval(value: number);
+    resetBufferingInterval(): void;
+    get bufferingIntervalInput(): number | undefined;
+    private _bufferingSize?;
+    get bufferingSize(): number;
+    set bufferingSize(value: number);
+    resetBufferingSize(): void;
+    get bufferingSizeInput(): number | undefined;
+    private _collectionEndpoint?;
+    get collectionEndpoint(): string;
+    set collectionEndpoint(value: string);
+    get collectionEndpointInput(): string | undefined;
+    private _indexName?;
+    get indexName(): string;
+    set indexName(value: string);
+    get indexNameInput(): string | undefined;
+    private _retryDuration?;
+    get retryDuration(): number;
+    set retryDuration(value: number);
+    resetRetryDuration(): void;
+    get retryDurationInput(): number | undefined;
+    private _roleArn?;
+    get roleArn(): string;
+    set roleArn(value: string);
+    get roleArnInput(): string | undefined;
+    private _s3BackupMode?;
+    get s3BackupMode(): string;
+    set s3BackupMode(value: string);
+    resetS3BackupMode(): void;
+    get s3BackupModeInput(): string | undefined;
+    private _cloudwatchLoggingOptions;
+    get cloudwatchLoggingOptions(): KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationCloudwatchLoggingOptionsOutputReference;
+    putCloudwatchLoggingOptions(value: KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationCloudwatchLoggingOptions): void;
+    resetCloudwatchLoggingOptions(): void;
+    get cloudwatchLoggingOptionsInput(): KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationCloudwatchLoggingOptions | undefined;
+    private _processingConfiguration;
+    get processingConfiguration(): KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationProcessingConfigurationOutputReference;
+    putProcessingConfiguration(value: KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationProcessingConfiguration): void;
+    resetProcessingConfiguration(): void;
+    get processingConfigurationInput(): KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationProcessingConfiguration | undefined;
+    private _s3Configuration;
+    get s3Configuration(): KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationS3ConfigurationOutputReference;
+    putS3Configuration(value: KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationS3Configuration): void;
+    get s3ConfigurationInput(): KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationS3Configuration | undefined;
+    private _vpcConfig;
+    get vpcConfig(): KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationVpcConfigOutputReference;
+    putVpcConfig(value: KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationVpcConfig): void;
+    resetVpcConfig(): void;
+    get vpcConfigInput(): KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationVpcConfig | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamRedshiftConfigurationCloudwatchLoggingOptions {
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#enabled KinesisFirehoseDeliveryStream#enabled}
+    */
+    readonly enabled?: boolean | cdktf.IResolvable;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#log_group_name KinesisFirehoseDeliveryStream#log_group_name}
+    */
+    readonly logGroupName?: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#log_stream_name KinesisFirehoseDeliveryStream#log_stream_name}
+    */
+    readonly logStreamName?: string;
+}
+export declare function kinesisFirehoseDeliveryStreamRedshiftConfigurationCloudwatchLoggingOptionsToTerraform(struct?: KinesisFirehoseDeliveryStreamRedshiftConfigurationCloudwatchLoggingOptionsOutputReference | KinesisFirehoseDeliveryStreamRedshiftConfigurationCloudwatchLoggingOptions): any;
+export declare function kinesisFirehoseDeliveryStreamRedshiftConfigurationCloudwatchLoggingOptionsToHclTerraform(struct?: KinesisFirehoseDeliveryStreamRedshiftConfigurationCloudwatchLoggingOptionsOutputReference | KinesisFirehoseDeliveryStreamRedshiftConfigurationCloudwatchLoggingOptions): any;
+export declare class KinesisFirehoseDeliveryStreamRedshiftConfigurationCloudwatchLoggingOptionsOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamRedshiftConfigurationCloudwatchLoggingOptions | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamRedshiftConfigurationCloudwatchLoggingOptions | undefined);
+    private _enabled?;
+    get enabled(): boolean | cdktf.IResolvable;
+    set enabled(value: boolean | cdktf.IResolvable);
+    resetEnabled(): void;
+    get enabledInput(): boolean | cdktf.IResolvable | undefined;
+    private _logGroupName?;
+    get logGroupName(): string;
+    set logGroupName(value: string);
+    resetLogGroupName(): void;
+    get logGroupNameInput(): string | undefined;
+    private _logStreamName?;
+    get logStreamName(): string;
+    set logStreamName(value: string);
+    resetLogStreamName(): void;
+    get logStreamNameInput(): string | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamRedshiftConfigurationProcessingConfigurationProcessorsParameters {
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#parameter_name KinesisFirehoseDeliveryStream#parameter_name}
+    */
+    readonly parameterName: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#parameter_value KinesisFirehoseDeliveryStream#parameter_value}
+    */
+    readonly parameterValue: string;
+}
+export declare function kinesisFirehoseDeliveryStreamRedshiftConfigurationProcessingConfigurationProcessorsParametersToTerraform(struct?: KinesisFirehoseDeliveryStreamRedshiftConfigurationProcessingConfigurationProcessorsParameters | cdktf.IResolvable): any;
+export declare function kinesisFirehoseDeliveryStreamRedshiftConfigurationProcessingConfigurationProcessorsParametersToHclTerraform(struct?: KinesisFirehoseDeliveryStreamRedshiftConfigurationProcessingConfigurationProcessorsParameters | cdktf.IResolvable): any;
+export declare class KinesisFirehoseDeliveryStreamRedshiftConfigurationProcessingConfigurationProcessorsParametersOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    private resolvableValue?;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    * @param complexObjectIndex the index of this item in the list
+    * @param complexObjectIsFromSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string, complexObjectIndex: number, complexObjectIsFromSet: boolean);
+    get internalValue(): KinesisFirehoseDeliveryStreamRedshiftConfigurationProcessingConfigurationProcessorsParameters | cdktf.IResolvable | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamRedshiftConfigurationProcessingConfigurationProcessorsParameters | cdktf.IResolvable | undefined);
+    private _parameterName?;
+    get parameterName(): string;
+    set parameterName(value: string);
+    get parameterNameInput(): string | undefined;
+    private _parameterValue?;
+    get parameterValue(): string;
+    set parameterValue(value: string);
+    get parameterValueInput(): string | undefined;
+}
+export declare class KinesisFirehoseDeliveryStreamRedshiftConfigurationProcessingConfigurationProcessorsParametersList extends cdktf.ComplexList {
+    protected terraformResource: cdktf.IInterpolatingParent;
+    protected terraformAttribute: string;
+    protected wrapsSet: boolean;
+    internalValue?: KinesisFirehoseDeliveryStreamRedshiftConfigurationProcessingConfigurationProcessorsParameters[] | cdktf.IResolvable;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    * @param wrapsSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string, wrapsSet: boolean);
+    /**
+    * @param index the index of the item to return
+    */
+    get(index: number): KinesisFirehoseDeliveryStreamRedshiftConfigurationProcessingConfigurationProcessorsParametersOutputReference;
+}
+export interface KinesisFirehoseDeliveryStreamRedshiftConfigurationProcessingConfigurationProcessors {
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#type KinesisFirehoseDeliveryStream#type}
+    */
+    readonly type: string;
+    /**
+    * parameters block
+    *
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#parameters KinesisFirehoseDeliveryStream#parameters}
+    */
+    readonly parameters?: KinesisFirehoseDeliveryStreamRedshiftConfigurationProcessingConfigurationProcessorsParameters[] | cdktf.IResolvable;
+}
+export declare function kinesisFirehoseDeliveryStreamRedshiftConfigurationProcessingConfigurationProcessorsToTerraform(struct?: KinesisFirehoseDeliveryStreamRedshiftConfigurationProcessingConfigurationProcessors | cdktf.IResolvable): any;
+export declare function kinesisFirehoseDeliveryStreamRedshiftConfigurationProcessingConfigurationProcessorsToHclTerraform(struct?: KinesisFirehoseDeliveryStreamRedshiftConfigurationProcessingConfigurationProcessors | cdktf.IResolvable): any;
+export declare class KinesisFirehoseDeliveryStreamRedshiftConfigurationProcessingConfigurationProcessorsOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    private resolvableValue?;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    * @param complexObjectIndex the index of this item in the list
+    * @param complexObjectIsFromSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string, complexObjectIndex: number, complexObjectIsFromSet: boolean);
+    get internalValue(): KinesisFirehoseDeliveryStreamRedshiftConfigurationProcessingConfigurationProcessors | cdktf.IResolvable | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamRedshiftConfigurationProcessingConfigurationProcessors | cdktf.IResolvable | undefined);
+    private _type?;
+    get type(): string;
+    set type(value: string);
+    get typeInput(): string | undefined;
+    private _parameters;
+    get parameters(): KinesisFirehoseDeliveryStreamRedshiftConfigurationProcessingConfigurationProcessorsParametersList;
+    putParameters(value: KinesisFirehoseDeliveryStreamRedshiftConfigurationProcessingConfigurationProcessorsParameters[] | cdktf.IResolvable): void;
+    resetParameters(): void;
+    get parametersInput(): cdktf.IResolvable | KinesisFirehoseDeliveryStreamRedshiftConfigurationProcessingConfigurationProcessorsParameters[] | undefined;
+}
+export declare class KinesisFirehoseDeliveryStreamRedshiftConfigurationProcessingConfigurationProcessorsList extends cdktf.ComplexList {
+    protected terraformResource: cdktf.IInterpolatingParent;
+    protected terraformAttribute: string;
+    protected wrapsSet: boolean;
+    internalValue?: KinesisFirehoseDeliveryStreamRedshiftConfigurationProcessingConfigurationProcessors[] | cdktf.IResolvable;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    * @param wrapsSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string, wrapsSet: boolean);
+    /**
+    * @param index the index of the item to return
+    */
+    get(index: number): KinesisFirehoseDeliveryStreamRedshiftConfigurationProcessingConfigurationProcessorsOutputReference;
+}
+export interface KinesisFirehoseDeliveryStreamRedshiftConfigurationProcessingConfiguration {
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#enabled KinesisFirehoseDeliveryStream#enabled}
+    */
+    readonly enabled?: boolean | cdktf.IResolvable;
+    /**
+    * processors block
+    *
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#processors KinesisFirehoseDeliveryStream#processors}
+    */
+    readonly processors?: KinesisFirehoseDeliveryStreamRedshiftConfigurationProcessingConfigurationProcessors[] | cdktf.IResolvable;
+}
+export declare function kinesisFirehoseDeliveryStreamRedshiftConfigurationProcessingConfigurationToTerraform(struct?: KinesisFirehoseDeliveryStreamRedshiftConfigurationProcessingConfigurationOutputReference | KinesisFirehoseDeliveryStreamRedshiftConfigurationProcessingConfiguration): any;
+export declare function kinesisFirehoseDeliveryStreamRedshiftConfigurationProcessingConfigurationToHclTerraform(struct?: KinesisFirehoseDeliveryStreamRedshiftConfigurationProcessingConfigurationOutputReference | KinesisFirehoseDeliveryStreamRedshiftConfigurationProcessingConfiguration): any;
+export declare class KinesisFirehoseDeliveryStreamRedshiftConfigurationProcessingConfigurationOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamRedshiftConfigurationProcessingConfiguration | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamRedshiftConfigurationProcessingConfiguration | undefined);
+    private _enabled?;
+    get enabled(): boolean | cdktf.IResolvable;
+    set enabled(value: boolean | cdktf.IResolvable);
+    resetEnabled(): void;
+    get enabledInput(): boolean | cdktf.IResolvable | undefined;
+    private _processors;
+    get processors(): KinesisFirehoseDeliveryStreamRedshiftConfigurationProcessingConfigurationProcessorsList;
+    putProcessors(value: KinesisFirehoseDeliveryStreamRedshiftConfigurationProcessingConfigurationProcessors[] | cdktf.IResolvable): void;
+    resetProcessors(): void;
+    get processorsInput(): cdktf.IResolvable | KinesisFirehoseDeliveryStreamRedshiftConfigurationProcessingConfigurationProcessors[] | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamRedshiftConfigurationS3BackupConfigurationCloudwatchLoggingOptions {
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#enabled KinesisFirehoseDeliveryStream#enabled}
+    */
+    readonly enabled?: boolean | cdktf.IResolvable;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#log_group_name KinesisFirehoseDeliveryStream#log_group_name}
+    */
+    readonly logGroupName?: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#log_stream_name KinesisFirehoseDeliveryStream#log_stream_name}
+    */
+    readonly logStreamName?: string;
+}
+export declare function kinesisFirehoseDeliveryStreamRedshiftConfigurationS3BackupConfigurationCloudwatchLoggingOptionsToTerraform(struct?: KinesisFirehoseDeliveryStreamRedshiftConfigurationS3BackupConfigurationCloudwatchLoggingOptionsOutputReference | KinesisFirehoseDeliveryStreamRedshiftConfigurationS3BackupConfigurationCloudwatchLoggingOptions): any;
+export declare function kinesisFirehoseDeliveryStreamRedshiftConfigurationS3BackupConfigurationCloudwatchLoggingOptionsToHclTerraform(struct?: KinesisFirehoseDeliveryStreamRedshiftConfigurationS3BackupConfigurationCloudwatchLoggingOptionsOutputReference | KinesisFirehoseDeliveryStreamRedshiftConfigurationS3BackupConfigurationCloudwatchLoggingOptions): any;
+export declare class KinesisFirehoseDeliveryStreamRedshiftConfigurationS3BackupConfigurationCloudwatchLoggingOptionsOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamRedshiftConfigurationS3BackupConfigurationCloudwatchLoggingOptions | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamRedshiftConfigurationS3BackupConfigurationCloudwatchLoggingOptions | undefined);
+    private _enabled?;
+    get enabled(): boolean | cdktf.IResolvable;
+    set enabled(value: boolean | cdktf.IResolvable);
+    resetEnabled(): void;
+    get enabledInput(): boolean | cdktf.IResolvable | undefined;
+    private _logGroupName?;
+    get logGroupName(): string;
+    set logGroupName(value: string);
+    resetLogGroupName(): void;
+    get logGroupNameInput(): string | undefined;
+    private _logStreamName?;
+    get logStreamName(): string;
+    set logStreamName(value: string);
+    resetLogStreamName(): void;
+    get logStreamNameInput(): string | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamRedshiftConfigurationS3BackupConfiguration {
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#bucket_arn KinesisFirehoseDeliveryStream#bucket_arn}
+    */
+    readonly bucketArn: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#buffering_interval KinesisFirehoseDeliveryStream#buffering_interval}
+    */
+    readonly bufferingInterval?: number;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#buffering_size KinesisFirehoseDeliveryStream#buffering_size}
+    */
+    readonly bufferingSize?: number;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#compression_format KinesisFirehoseDeliveryStream#compression_format}
+    */
+    readonly compressionFormat?: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#error_output_prefix KinesisFirehoseDeliveryStream#error_output_prefix}
+    */
+    readonly errorOutputPrefix?: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#kms_key_arn KinesisFirehoseDeliveryStream#kms_key_arn}
+    */
+    readonly kmsKeyArn?: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#prefix KinesisFirehoseDeliveryStream#prefix}
+    */
+    readonly prefix?: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#role_arn KinesisFirehoseDeliveryStream#role_arn}
+    */
+    readonly roleArn: string;
+    /**
+    * cloudwatch_logging_options block
+    *
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#cloudwatch_logging_options KinesisFirehoseDeliveryStream#cloudwatch_logging_options}
+    */
+    readonly cloudwatchLoggingOptions?: KinesisFirehoseDeliveryStreamRedshiftConfigurationS3BackupConfigurationCloudwatchLoggingOptions;
+}
+export declare function kinesisFirehoseDeliveryStreamRedshiftConfigurationS3BackupConfigurationToTerraform(struct?: KinesisFirehoseDeliveryStreamRedshiftConfigurationS3BackupConfigurationOutputReference | KinesisFirehoseDeliveryStreamRedshiftConfigurationS3BackupConfiguration): any;
+export declare function kinesisFirehoseDeliveryStreamRedshiftConfigurationS3BackupConfigurationToHclTerraform(struct?: KinesisFirehoseDeliveryStreamRedshiftConfigurationS3BackupConfigurationOutputReference | KinesisFirehoseDeliveryStreamRedshiftConfigurationS3BackupConfiguration): any;
+export declare class KinesisFirehoseDeliveryStreamRedshiftConfigurationS3BackupConfigurationOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamRedshiftConfigurationS3BackupConfiguration | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamRedshiftConfigurationS3BackupConfiguration | undefined);
+    private _bucketArn?;
+    get bucketArn(): string;
+    set bucketArn(value: string);
+    get bucketArnInput(): string | undefined;
+    private _bufferingInterval?;
+    get bufferingInterval(): number;
+    set bufferingInterval(value: number);
+    resetBufferingInterval(): void;
+    get bufferingIntervalInput(): number | undefined;
+    private _bufferingSize?;
+    get bufferingSize(): number;
+    set bufferingSize(value: number);
+    resetBufferingSize(): void;
+    get bufferingSizeInput(): number | undefined;
+    private _compressionFormat?;
+    get compressionFormat(): string;
+    set compressionFormat(value: string);
+    resetCompressionFormat(): void;
+    get compressionFormatInput(): string | undefined;
+    private _errorOutputPrefix?;
+    get errorOutputPrefix(): string;
+    set errorOutputPrefix(value: string);
+    resetErrorOutputPrefix(): void;
+    get errorOutputPrefixInput(): string | undefined;
+    private _kmsKeyArn?;
+    get kmsKeyArn(): string;
+    set kmsKeyArn(value: string);
+    resetKmsKeyArn(): void;
+    get kmsKeyArnInput(): string | undefined;
+    private _prefix?;
+    get prefix(): string;
+    set prefix(value: string);
+    resetPrefix(): void;
+    get prefixInput(): string | undefined;
+    private _roleArn?;
+    get roleArn(): string;
+    set roleArn(value: string);
+    get roleArnInput(): string | undefined;
+    private _cloudwatchLoggingOptions;
+    get cloudwatchLoggingOptions(): KinesisFirehoseDeliveryStreamRedshiftConfigurationS3BackupConfigurationCloudwatchLoggingOptionsOutputReference;
+    putCloudwatchLoggingOptions(value: KinesisFirehoseDeliveryStreamRedshiftConfigurationS3BackupConfigurationCloudwatchLoggingOptions): void;
+    resetCloudwatchLoggingOptions(): void;
+    get cloudwatchLoggingOptionsInput(): KinesisFirehoseDeliveryStreamRedshiftConfigurationS3BackupConfigurationCloudwatchLoggingOptions | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamRedshiftConfigurationS3ConfigurationCloudwatchLoggingOptions {
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#enabled KinesisFirehoseDeliveryStream#enabled}
+    */
+    readonly enabled?: boolean | cdktf.IResolvable;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#log_group_name KinesisFirehoseDeliveryStream#log_group_name}
+    */
+    readonly logGroupName?: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#log_stream_name KinesisFirehoseDeliveryStream#log_stream_name}
+    */
+    readonly logStreamName?: string;
+}
+export declare function kinesisFirehoseDeliveryStreamRedshiftConfigurationS3ConfigurationCloudwatchLoggingOptionsToTerraform(struct?: KinesisFirehoseDeliveryStreamRedshiftConfigurationS3ConfigurationCloudwatchLoggingOptionsOutputReference | KinesisFirehoseDeliveryStreamRedshiftConfigurationS3ConfigurationCloudwatchLoggingOptions): any;
+export declare function kinesisFirehoseDeliveryStreamRedshiftConfigurationS3ConfigurationCloudwatchLoggingOptionsToHclTerraform(struct?: KinesisFirehoseDeliveryStreamRedshiftConfigurationS3ConfigurationCloudwatchLoggingOptionsOutputReference | KinesisFirehoseDeliveryStreamRedshiftConfigurationS3ConfigurationCloudwatchLoggingOptions): any;
+export declare class KinesisFirehoseDeliveryStreamRedshiftConfigurationS3ConfigurationCloudwatchLoggingOptionsOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamRedshiftConfigurationS3ConfigurationCloudwatchLoggingOptions | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamRedshiftConfigurationS3ConfigurationCloudwatchLoggingOptions | undefined);
+    private _enabled?;
+    get enabled(): boolean | cdktf.IResolvable;
+    set enabled(value: boolean | cdktf.IResolvable);
+    resetEnabled(): void;
+    get enabledInput(): boolean | cdktf.IResolvable | undefined;
+    private _logGroupName?;
+    get logGroupName(): string;
+    set logGroupName(value: string);
+    resetLogGroupName(): void;
+    get logGroupNameInput(): string | undefined;
+    private _logStreamName?;
+    get logStreamName(): string;
+    set logStreamName(value: string);
+    resetLogStreamName(): void;
+    get logStreamNameInput(): string | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamRedshiftConfigurationS3Configuration {
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#bucket_arn KinesisFirehoseDeliveryStream#bucket_arn}
+    */
+    readonly bucketArn: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#buffering_interval KinesisFirehoseDeliveryStream#buffering_interval}
+    */
+    readonly bufferingInterval?: number;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#buffering_size KinesisFirehoseDeliveryStream#buffering_size}
+    */
+    readonly bufferingSize?: number;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#compression_format KinesisFirehoseDeliveryStream#compression_format}
+    */
+    readonly compressionFormat?: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#error_output_prefix KinesisFirehoseDeliveryStream#error_output_prefix}
+    */
+    readonly errorOutputPrefix?: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#kms_key_arn KinesisFirehoseDeliveryStream#kms_key_arn}
+    */
+    readonly kmsKeyArn?: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#prefix KinesisFirehoseDeliveryStream#prefix}
+    */
+    readonly prefix?: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#role_arn KinesisFirehoseDeliveryStream#role_arn}
+    */
+    readonly roleArn: string;
+    /**
+    * cloudwatch_logging_options block
+    *
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#cloudwatch_logging_options KinesisFirehoseDeliveryStream#cloudwatch_logging_options}
+    */
+    readonly cloudwatchLoggingOptions?: KinesisFirehoseDeliveryStreamRedshiftConfigurationS3ConfigurationCloudwatchLoggingOptions;
+}
+export declare function kinesisFirehoseDeliveryStreamRedshiftConfigurationS3ConfigurationToTerraform(struct?: KinesisFirehoseDeliveryStreamRedshiftConfigurationS3ConfigurationOutputReference | KinesisFirehoseDeliveryStreamRedshiftConfigurationS3Configuration): any;
+export declare function kinesisFirehoseDeliveryStreamRedshiftConfigurationS3ConfigurationToHclTerraform(struct?: KinesisFirehoseDeliveryStreamRedshiftConfigurationS3ConfigurationOutputReference | KinesisFirehoseDeliveryStreamRedshiftConfigurationS3Configuration): any;
+export declare class KinesisFirehoseDeliveryStreamRedshiftConfigurationS3ConfigurationOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamRedshiftConfigurationS3Configuration | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamRedshiftConfigurationS3Configuration | undefined);
+    private _bucketArn?;
+    get bucketArn(): string;
+    set bucketArn(value: string);
+    get bucketArnInput(): string | undefined;
+    private _bufferingInterval?;
+    get bufferingInterval(): number;
+    set bufferingInterval(value: number);
+    resetBufferingInterval(): void;
+    get bufferingIntervalInput(): number | undefined;
+    private _bufferingSize?;
+    get bufferingSize(): number;
+    set bufferingSize(value: number);
+    resetBufferingSize(): void;
+    get bufferingSizeInput(): number | undefined;
+    private _compressionFormat?;
+    get compressionFormat(): string;
+    set compressionFormat(value: string);
+    resetCompressionFormat(): void;
+    get compressionFormatInput(): string | undefined;
+    private _errorOutputPrefix?;
+    get errorOutputPrefix(): string;
+    set errorOutputPrefix(value: string);
+    resetErrorOutputPrefix(): void;
+    get errorOutputPrefixInput(): string | undefined;
+    private _kmsKeyArn?;
+    get kmsKeyArn(): string;
+    set kmsKeyArn(value: string);
+    resetKmsKeyArn(): void;
+    get kmsKeyArnInput(): string | undefined;
+    private _prefix?;
+    get prefix(): string;
+    set prefix(value: string);
+    resetPrefix(): void;
+    get prefixInput(): string | undefined;
+    private _roleArn?;
+    get roleArn(): string;
+    set roleArn(value: string);
+    get roleArnInput(): string | undefined;
+    private _cloudwatchLoggingOptions;
+    get cloudwatchLoggingOptions(): KinesisFirehoseDeliveryStreamRedshiftConfigurationS3ConfigurationCloudwatchLoggingOptionsOutputReference;
+    putCloudwatchLoggingOptions(value: KinesisFirehoseDeliveryStreamRedshiftConfigurationS3ConfigurationCloudwatchLoggingOptions): void;
+    resetCloudwatchLoggingOptions(): void;
+    get cloudwatchLoggingOptionsInput(): KinesisFirehoseDeliveryStreamRedshiftConfigurationS3ConfigurationCloudwatchLoggingOptions | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamRedshiftConfigurationSecretsManagerConfiguration {
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#enabled KinesisFirehoseDeliveryStream#enabled}
+    */
+    readonly enabled?: boolean | cdktf.IResolvable;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#role_arn KinesisFirehoseDeliveryStream#role_arn}
+    */
+    readonly roleArn?: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#secret_arn KinesisFirehoseDeliveryStream#secret_arn}
+    */
+    readonly secretArn?: string;
+}
+export declare function kinesisFirehoseDeliveryStreamRedshiftConfigurationSecretsManagerConfigurationToTerraform(struct?: KinesisFirehoseDeliveryStreamRedshiftConfigurationSecretsManagerConfigurationOutputReference | KinesisFirehoseDeliveryStreamRedshiftConfigurationSecretsManagerConfiguration): any;
+export declare function kinesisFirehoseDeliveryStreamRedshiftConfigurationSecretsManagerConfigurationToHclTerraform(struct?: KinesisFirehoseDeliveryStreamRedshiftConfigurationSecretsManagerConfigurationOutputReference | KinesisFirehoseDeliveryStreamRedshiftConfigurationSecretsManagerConfiguration): any;
+export declare class KinesisFirehoseDeliveryStreamRedshiftConfigurationSecretsManagerConfigurationOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamRedshiftConfigurationSecretsManagerConfiguration | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamRedshiftConfigurationSecretsManagerConfiguration | undefined);
+    private _enabled?;
+    get enabled(): boolean | cdktf.IResolvable;
+    set enabled(value: boolean | cdktf.IResolvable);
+    resetEnabled(): void;
+    get enabledInput(): boolean | cdktf.IResolvable | undefined;
+    private _roleArn?;
+    get roleArn(): string;
+    set roleArn(value: string);
+    resetRoleArn(): void;
+    get roleArnInput(): string | undefined;
+    private _secretArn?;
+    get secretArn(): string;
+    set secretArn(value: string);
+    resetSecretArn(): void;
+    get secretArnInput(): string | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamRedshiftConfiguration {
+    /** (Required) The jdbcurl of the redshift cluster. */
+    readonly clusterJdbcurl: string;
+    /** (Optional) Copy options for copying the data from the s3 intermediate bucket into redshift, for example to change the default delimiter. For valid values, see the [AWS documentation](http://docs.aws.amazon.com/firehose/latest/APIReference/API_CopyCommand.html) */
+    readonly copyOptions?: string;
+    /** (Optional) The data table columns that will be targeted by the copy command. */
+    readonly dataTableColumns?: string;
+    /** (Required) The name of the table in the redshift cluster that the s3 bucket will copy to. */
+    readonly dataTableName: string;
+    /** (Optional) The password for the username above. This value is required if `secretsManagerConfiguration` is not provided. */
+    readonly password?: string;
+    /** (Optional) The length of time during which Firehose retries delivery after a failure, starting from the initial request and including the first attempt. The default value is 3600 seconds (60 minutes). Firehose does not retry if the value of DurationInSeconds is 0 (zero) or if the first delivery attempt takes longer than the current value. */
+    readonly retryDuration?: number;
+    /** (Required) The arn of the role the stream assumes. */
+    readonly roleArn: string;
+    /** (Optional) The Amazon S3 backup mode.  Valid values are `Disabled` and `Enabled`.  Default value is `Disabled`. */
+    readonly s3BackupMode?: string;
+    /** (Optional) The username that the firehose delivery stream will assume. It is strongly recommended that the username and password provided is used exclusively for Amazon Kinesis Firehose purposes, and that the permissions for the account are restricted for Amazon Redshift INSERT permissions. This value is required if `secretsManagerConfiguration` is not provided. */
+    readonly username?: string;
+    /** */
+    readonly cloudwatchLoggingOptions?: KinesisFirehoseDeliveryStreamRedshiftConfigurationCloudwatchLoggingOptions;
+    /** */
+    readonly processingConfiguration?: KinesisFirehoseDeliveryStreamRedshiftConfigurationProcessingConfiguration;
+    /** */
+    readonly s3BackupConfiguration?: KinesisFirehoseDeliveryStreamRedshiftConfigurationS3BackupConfiguration;
+    /** */
+    readonly s3Configuration: KinesisFirehoseDeliveryStreamRedshiftConfigurationS3Configuration;
+    /** */
+    readonly secretsManagerConfiguration?: KinesisFirehoseDeliveryStreamRedshiftConfigurationSecretsManagerConfiguration;
+}
+export declare function kinesisFirehoseDeliveryStreamRedshiftConfigurationToTerraform(struct?: KinesisFirehoseDeliveryStreamRedshiftConfigurationOutputReference | KinesisFirehoseDeliveryStreamRedshiftConfiguration): any;
+export declare function kinesisFirehoseDeliveryStreamRedshiftConfigurationToHclTerraform(struct?: KinesisFirehoseDeliveryStreamRedshiftConfigurationOutputReference | KinesisFirehoseDeliveryStreamRedshiftConfiguration): any;
+export declare class KinesisFirehoseDeliveryStreamRedshiftConfigurationOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamRedshiftConfiguration | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamRedshiftConfiguration | undefined);
+    private _clusterJdbcurl?;
+    get clusterJdbcurl(): string;
+    set clusterJdbcurl(value: string);
+    get clusterJdbcurlInput(): string | undefined;
+    private _copyOptions?;
+    get copyOptions(): string;
+    set copyOptions(value: string);
+    resetCopyOptions(): void;
+    get copyOptionsInput(): string | undefined;
+    private _dataTableColumns?;
+    get dataTableColumns(): string;
+    set dataTableColumns(value: string);
+    resetDataTableColumns(): void;
+    get dataTableColumnsInput(): string | undefined;
+    private _dataTableName?;
+    get dataTableName(): string;
+    set dataTableName(value: string);
+    get dataTableNameInput(): string | undefined;
+    private _password?;
+    get password(): string;
+    set password(value: string);
+    resetPassword(): void;
+    get passwordInput(): string | undefined;
+    private _retryDuration?;
+    get retryDuration(): number;
+    set retryDuration(value: number);
+    resetRetryDuration(): void;
+    get retryDurationInput(): number | undefined;
+    private _roleArn?;
+    get roleArn(): string;
+    set roleArn(value: string);
+    get roleArnInput(): string | undefined;
+    private _s3BackupMode?;
+    get s3BackupMode(): string;
+    set s3BackupMode(value: string);
+    resetS3BackupMode(): void;
+    get s3BackupModeInput(): string | undefined;
+    private _username?;
+    get username(): string;
+    set username(value: string);
+    resetUsername(): void;
+    get usernameInput(): string | undefined;
+    private _cloudwatchLoggingOptions;
+    get cloudwatchLoggingOptions(): KinesisFirehoseDeliveryStreamRedshiftConfigurationCloudwatchLoggingOptionsOutputReference;
+    putCloudwatchLoggingOptions(value: KinesisFirehoseDeliveryStreamRedshiftConfigurationCloudwatchLoggingOptions): void;
+    resetCloudwatchLoggingOptions(): void;
+    get cloudwatchLoggingOptionsInput(): KinesisFirehoseDeliveryStreamRedshiftConfigurationCloudwatchLoggingOptions | undefined;
+    private _processingConfiguration;
+    get processingConfiguration(): KinesisFirehoseDeliveryStreamRedshiftConfigurationProcessingConfigurationOutputReference;
+    putProcessingConfiguration(value: KinesisFirehoseDeliveryStreamRedshiftConfigurationProcessingConfiguration): void;
+    resetProcessingConfiguration(): void;
+    get processingConfigurationInput(): KinesisFirehoseDeliveryStreamRedshiftConfigurationProcessingConfiguration | undefined;
+    private _s3BackupConfiguration;
+    get s3BackupConfiguration(): KinesisFirehoseDeliveryStreamRedshiftConfigurationS3BackupConfigurationOutputReference;
+    putS3BackupConfiguration(value: KinesisFirehoseDeliveryStreamRedshiftConfigurationS3BackupConfiguration): void;
+    resetS3BackupConfiguration(): void;
+    get s3BackupConfigurationInput(): KinesisFirehoseDeliveryStreamRedshiftConfigurationS3BackupConfiguration | undefined;
+    private _s3Configuration;
+    get s3Configuration(): KinesisFirehoseDeliveryStreamRedshiftConfigurationS3ConfigurationOutputReference;
+    putS3Configuration(value: KinesisFirehoseDeliveryStreamRedshiftConfigurationS3Configuration): void;
+    get s3ConfigurationInput(): KinesisFirehoseDeliveryStreamRedshiftConfigurationS3Configuration | undefined;
+    private _secretsManagerConfiguration;
+    get secretsManagerConfiguration(): KinesisFirehoseDeliveryStreamRedshiftConfigurationSecretsManagerConfigurationOutputReference;
+    putSecretsManagerConfiguration(value: KinesisFirehoseDeliveryStreamRedshiftConfigurationSecretsManagerConfiguration): void;
+    resetSecretsManagerConfiguration(): void;
+    get secretsManagerConfigurationInput(): KinesisFirehoseDeliveryStreamRedshiftConfigurationSecretsManagerConfiguration | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamServerSideEncryption {
+    /** (Optional) Whether to enable encryption at rest. Default is `false`. */
+    readonly enabled?: boolean | cdktf.IResolvable;
+    /** (Optional) Amazon Resource Name (ARN) of the encryption key. Required when `keyType` is `CUSTOMER_MANAGED_CMK`. */
+    readonly keyArn?: string;
+    /** (Optional) Type of encryption key. Default is `AWS_OWNED_CMK`. Valid values are `AWS_OWNED_CMK` and `CUSTOMER_MANAGED_CMK` */
+    readonly keyType?: string;
+}
+export declare function kinesisFirehoseDeliveryStreamServerSideEncryptionToTerraform(struct?: KinesisFirehoseDeliveryStreamServerSideEncryptionOutputReference | KinesisFirehoseDeliveryStreamServerSideEncryption): any;
+export declare function kinesisFirehoseDeliveryStreamServerSideEncryptionToHclTerraform(struct?: KinesisFirehoseDeliveryStreamServerSideEncryptionOutputReference | KinesisFirehoseDeliveryStreamServerSideEncryption): any;
+export declare class KinesisFirehoseDeliveryStreamServerSideEncryptionOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamServerSideEncryption | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamServerSideEncryption | undefined);
+    private _enabled?;
+    get enabled(): boolean | cdktf.IResolvable;
+    set enabled(value: boolean | cdktf.IResolvable);
+    resetEnabled(): void;
+    get enabledInput(): boolean | cdktf.IResolvable | undefined;
+    private _keyArn?;
+    get keyArn(): string;
+    set keyArn(value: string);
+    resetKeyArn(): void;
+    get keyArnInput(): string | undefined;
+    private _keyType?;
+    get keyType(): string;
+    set keyType(value: string);
+    resetKeyType(): void;
+    get keyTypeInput(): string | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamSnowflakeConfigurationCloudwatchLoggingOptions {
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#enabled KinesisFirehoseDeliveryStream#enabled}
+    */
+    readonly enabled?: boolean | cdktf.IResolvable;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#log_group_name KinesisFirehoseDeliveryStream#log_group_name}
+    */
+    readonly logGroupName?: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#log_stream_name KinesisFirehoseDeliveryStream#log_stream_name}
+    */
+    readonly logStreamName?: string;
+}
+export declare function kinesisFirehoseDeliveryStreamSnowflakeConfigurationCloudwatchLoggingOptionsToTerraform(struct?: KinesisFirehoseDeliveryStreamSnowflakeConfigurationCloudwatchLoggingOptionsOutputReference | KinesisFirehoseDeliveryStreamSnowflakeConfigurationCloudwatchLoggingOptions): any;
+export declare function kinesisFirehoseDeliveryStreamSnowflakeConfigurationCloudwatchLoggingOptionsToHclTerraform(struct?: KinesisFirehoseDeliveryStreamSnowflakeConfigurationCloudwatchLoggingOptionsOutputReference | KinesisFirehoseDeliveryStreamSnowflakeConfigurationCloudwatchLoggingOptions): any;
+export declare class KinesisFirehoseDeliveryStreamSnowflakeConfigurationCloudwatchLoggingOptionsOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamSnowflakeConfigurationCloudwatchLoggingOptions | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamSnowflakeConfigurationCloudwatchLoggingOptions | undefined);
+    private _enabled?;
+    get enabled(): boolean | cdktf.IResolvable;
+    set enabled(value: boolean | cdktf.IResolvable);
+    resetEnabled(): void;
+    get enabledInput(): boolean | cdktf.IResolvable | undefined;
+    private _logGroupName?;
+    get logGroupName(): string;
+    set logGroupName(value: string);
+    resetLogGroupName(): void;
+    get logGroupNameInput(): string | undefined;
+    private _logStreamName?;
+    get logStreamName(): string;
+    set logStreamName(value: string);
+    resetLogStreamName(): void;
+    get logStreamNameInput(): string | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamSnowflakeConfigurationProcessingConfigurationProcessorsParameters {
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#parameter_name KinesisFirehoseDeliveryStream#parameter_name}
+    */
+    readonly parameterName: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#parameter_value KinesisFirehoseDeliveryStream#parameter_value}
+    */
+    readonly parameterValue: string;
+}
+export declare function kinesisFirehoseDeliveryStreamSnowflakeConfigurationProcessingConfigurationProcessorsParametersToTerraform(struct?: KinesisFirehoseDeliveryStreamSnowflakeConfigurationProcessingConfigurationProcessorsParameters | cdktf.IResolvable): any;
+export declare function kinesisFirehoseDeliveryStreamSnowflakeConfigurationProcessingConfigurationProcessorsParametersToHclTerraform(struct?: KinesisFirehoseDeliveryStreamSnowflakeConfigurationProcessingConfigurationProcessorsParameters | cdktf.IResolvable): any;
+export declare class KinesisFirehoseDeliveryStreamSnowflakeConfigurationProcessingConfigurationProcessorsParametersOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    private resolvableValue?;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    * @param complexObjectIndex the index of this item in the list
+    * @param complexObjectIsFromSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string, complexObjectIndex: number, complexObjectIsFromSet: boolean);
+    get internalValue(): KinesisFirehoseDeliveryStreamSnowflakeConfigurationProcessingConfigurationProcessorsParameters | cdktf.IResolvable | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamSnowflakeConfigurationProcessingConfigurationProcessorsParameters | cdktf.IResolvable | undefined);
+    private _parameterName?;
+    get parameterName(): string;
+    set parameterName(value: string);
+    get parameterNameInput(): string | undefined;
+    private _parameterValue?;
+    get parameterValue(): string;
+    set parameterValue(value: string);
+    get parameterValueInput(): string | undefined;
+}
+export declare class KinesisFirehoseDeliveryStreamSnowflakeConfigurationProcessingConfigurationProcessorsParametersList extends cdktf.ComplexList {
+    protected terraformResource: cdktf.IInterpolatingParent;
+    protected terraformAttribute: string;
+    protected wrapsSet: boolean;
+    internalValue?: KinesisFirehoseDeliveryStreamSnowflakeConfigurationProcessingConfigurationProcessorsParameters[] | cdktf.IResolvable;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    * @param wrapsSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string, wrapsSet: boolean);
+    /**
+    * @param index the index of the item to return
+    */
+    get(index: number): KinesisFirehoseDeliveryStreamSnowflakeConfigurationProcessingConfigurationProcessorsParametersOutputReference;
+}
+export interface KinesisFirehoseDeliveryStreamSnowflakeConfigurationProcessingConfigurationProcessors {
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#type KinesisFirehoseDeliveryStream#type}
+    */
+    readonly type: string;
+    /**
+    * parameters block
+    *
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#parameters KinesisFirehoseDeliveryStream#parameters}
+    */
+    readonly parameters?: KinesisFirehoseDeliveryStreamSnowflakeConfigurationProcessingConfigurationProcessorsParameters[] | cdktf.IResolvable;
+}
+export declare function kinesisFirehoseDeliveryStreamSnowflakeConfigurationProcessingConfigurationProcessorsToTerraform(struct?: KinesisFirehoseDeliveryStreamSnowflakeConfigurationProcessingConfigurationProcessors | cdktf.IResolvable): any;
+export declare function kinesisFirehoseDeliveryStreamSnowflakeConfigurationProcessingConfigurationProcessorsToHclTerraform(struct?: KinesisFirehoseDeliveryStreamSnowflakeConfigurationProcessingConfigurationProcessors | cdktf.IResolvable): any;
+export declare class KinesisFirehoseDeliveryStreamSnowflakeConfigurationProcessingConfigurationProcessorsOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    private resolvableValue?;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    * @param complexObjectIndex the index of this item in the list
+    * @param complexObjectIsFromSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string, complexObjectIndex: number, complexObjectIsFromSet: boolean);
+    get internalValue(): KinesisFirehoseDeliveryStreamSnowflakeConfigurationProcessingConfigurationProcessors | cdktf.IResolvable | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamSnowflakeConfigurationProcessingConfigurationProcessors | cdktf.IResolvable | undefined);
+    private _type?;
+    get type(): string;
+    set type(value: string);
+    get typeInput(): string | undefined;
+    private _parameters;
+    get parameters(): KinesisFirehoseDeliveryStreamSnowflakeConfigurationProcessingConfigurationProcessorsParametersList;
+    putParameters(value: KinesisFirehoseDeliveryStreamSnowflakeConfigurationProcessingConfigurationProcessorsParameters[] | cdktf.IResolvable): void;
+    resetParameters(): void;
+    get parametersInput(): cdktf.IResolvable | KinesisFirehoseDeliveryStreamSnowflakeConfigurationProcessingConfigurationProcessorsParameters[] | undefined;
+}
+export declare class KinesisFirehoseDeliveryStreamSnowflakeConfigurationProcessingConfigurationProcessorsList extends cdktf.ComplexList {
+    protected terraformResource: cdktf.IInterpolatingParent;
+    protected terraformAttribute: string;
+    protected wrapsSet: boolean;
+    internalValue?: KinesisFirehoseDeliveryStreamSnowflakeConfigurationProcessingConfigurationProcessors[] | cdktf.IResolvable;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    * @param wrapsSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string, wrapsSet: boolean);
+    /**
+    * @param index the index of the item to return
+    */
+    get(index: number): KinesisFirehoseDeliveryStreamSnowflakeConfigurationProcessingConfigurationProcessorsOutputReference;
+}
+export interface KinesisFirehoseDeliveryStreamSnowflakeConfigurationProcessingConfiguration {
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#enabled KinesisFirehoseDeliveryStream#enabled}
+    */
+    readonly enabled?: boolean | cdktf.IResolvable;
+    /**
+    * processors block
+    *
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#processors KinesisFirehoseDeliveryStream#processors}
+    */
+    readonly processors?: KinesisFirehoseDeliveryStreamSnowflakeConfigurationProcessingConfigurationProcessors[] | cdktf.IResolvable;
+}
+export declare function kinesisFirehoseDeliveryStreamSnowflakeConfigurationProcessingConfigurationToTerraform(struct?: KinesisFirehoseDeliveryStreamSnowflakeConfigurationProcessingConfigurationOutputReference | KinesisFirehoseDeliveryStreamSnowflakeConfigurationProcessingConfiguration): any;
+export declare function kinesisFirehoseDeliveryStreamSnowflakeConfigurationProcessingConfigurationToHclTerraform(struct?: KinesisFirehoseDeliveryStreamSnowflakeConfigurationProcessingConfigurationOutputReference | KinesisFirehoseDeliveryStreamSnowflakeConfigurationProcessingConfiguration): any;
+export declare class KinesisFirehoseDeliveryStreamSnowflakeConfigurationProcessingConfigurationOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamSnowflakeConfigurationProcessingConfiguration | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamSnowflakeConfigurationProcessingConfiguration | undefined);
+    private _enabled?;
+    get enabled(): boolean | cdktf.IResolvable;
+    set enabled(value: boolean | cdktf.IResolvable);
+    resetEnabled(): void;
+    get enabledInput(): boolean | cdktf.IResolvable | undefined;
+    private _processors;
+    get processors(): KinesisFirehoseDeliveryStreamSnowflakeConfigurationProcessingConfigurationProcessorsList;
+    putProcessors(value: KinesisFirehoseDeliveryStreamSnowflakeConfigurationProcessingConfigurationProcessors[] | cdktf.IResolvable): void;
+    resetProcessors(): void;
+    get processorsInput(): cdktf.IResolvable | KinesisFirehoseDeliveryStreamSnowflakeConfigurationProcessingConfigurationProcessors[] | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamSnowflakeConfigurationS3ConfigurationCloudwatchLoggingOptions {
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#enabled KinesisFirehoseDeliveryStream#enabled}
+    */
+    readonly enabled?: boolean | cdktf.IResolvable;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#log_group_name KinesisFirehoseDeliveryStream#log_group_name}
+    */
+    readonly logGroupName?: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#log_stream_name KinesisFirehoseDeliveryStream#log_stream_name}
+    */
+    readonly logStreamName?: string;
+}
+export declare function kinesisFirehoseDeliveryStreamSnowflakeConfigurationS3ConfigurationCloudwatchLoggingOptionsToTerraform(struct?: KinesisFirehoseDeliveryStreamSnowflakeConfigurationS3ConfigurationCloudwatchLoggingOptionsOutputReference | KinesisFirehoseDeliveryStreamSnowflakeConfigurationS3ConfigurationCloudwatchLoggingOptions): any;
+export declare function kinesisFirehoseDeliveryStreamSnowflakeConfigurationS3ConfigurationCloudwatchLoggingOptionsToHclTerraform(struct?: KinesisFirehoseDeliveryStreamSnowflakeConfigurationS3ConfigurationCloudwatchLoggingOptionsOutputReference | KinesisFirehoseDeliveryStreamSnowflakeConfigurationS3ConfigurationCloudwatchLoggingOptions): any;
+export declare class KinesisFirehoseDeliveryStreamSnowflakeConfigurationS3ConfigurationCloudwatchLoggingOptionsOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamSnowflakeConfigurationS3ConfigurationCloudwatchLoggingOptions | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamSnowflakeConfigurationS3ConfigurationCloudwatchLoggingOptions | undefined);
+    private _enabled?;
+    get enabled(): boolean | cdktf.IResolvable;
+    set enabled(value: boolean | cdktf.IResolvable);
+    resetEnabled(): void;
+    get enabledInput(): boolean | cdktf.IResolvable | undefined;
+    private _logGroupName?;
+    get logGroupName(): string;
+    set logGroupName(value: string);
+    resetLogGroupName(): void;
+    get logGroupNameInput(): string | undefined;
+    private _logStreamName?;
+    get logStreamName(): string;
+    set logStreamName(value: string);
+    resetLogStreamName(): void;
+    get logStreamNameInput(): string | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamSnowflakeConfigurationS3Configuration {
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#bucket_arn KinesisFirehoseDeliveryStream#bucket_arn}
+    */
+    readonly bucketArn: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#buffering_interval KinesisFirehoseDeliveryStream#buffering_interval}
+    */
+    readonly bufferingInterval?: number;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#buffering_size KinesisFirehoseDeliveryStream#buffering_size}
+    */
+    readonly bufferingSize?: number;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#compression_format KinesisFirehoseDeliveryStream#compression_format}
+    */
+    readonly compressionFormat?: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#error_output_prefix KinesisFirehoseDeliveryStream#error_output_prefix}
+    */
+    readonly errorOutputPrefix?: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#kms_key_arn KinesisFirehoseDeliveryStream#kms_key_arn}
+    */
+    readonly kmsKeyArn?: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#prefix KinesisFirehoseDeliveryStream#prefix}
+    */
+    readonly prefix?: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#role_arn KinesisFirehoseDeliveryStream#role_arn}
+    */
+    readonly roleArn: string;
+    /**
+    * cloudwatch_logging_options block
+    *
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#cloudwatch_logging_options KinesisFirehoseDeliveryStream#cloudwatch_logging_options}
+    */
+    readonly cloudwatchLoggingOptions?: KinesisFirehoseDeliveryStreamSnowflakeConfigurationS3ConfigurationCloudwatchLoggingOptions;
+}
+export declare function kinesisFirehoseDeliveryStreamSnowflakeConfigurationS3ConfigurationToTerraform(struct?: KinesisFirehoseDeliveryStreamSnowflakeConfigurationS3ConfigurationOutputReference | KinesisFirehoseDeliveryStreamSnowflakeConfigurationS3Configuration): any;
+export declare function kinesisFirehoseDeliveryStreamSnowflakeConfigurationS3ConfigurationToHclTerraform(struct?: KinesisFirehoseDeliveryStreamSnowflakeConfigurationS3ConfigurationOutputReference | KinesisFirehoseDeliveryStreamSnowflakeConfigurationS3Configuration): any;
+export declare class KinesisFirehoseDeliveryStreamSnowflakeConfigurationS3ConfigurationOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamSnowflakeConfigurationS3Configuration | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamSnowflakeConfigurationS3Configuration | undefined);
+    private _bucketArn?;
+    get bucketArn(): string;
+    set bucketArn(value: string);
+    get bucketArnInput(): string | undefined;
+    private _bufferingInterval?;
+    get bufferingInterval(): number;
+    set bufferingInterval(value: number);
+    resetBufferingInterval(): void;
+    get bufferingIntervalInput(): number | undefined;
+    private _bufferingSize?;
+    get bufferingSize(): number;
+    set bufferingSize(value: number);
+    resetBufferingSize(): void;
+    get bufferingSizeInput(): number | undefined;
+    private _compressionFormat?;
+    get compressionFormat(): string;
+    set compressionFormat(value: string);
+    resetCompressionFormat(): void;
+    get compressionFormatInput(): string | undefined;
+    private _errorOutputPrefix?;
+    get errorOutputPrefix(): string;
+    set errorOutputPrefix(value: string);
+    resetErrorOutputPrefix(): void;
+    get errorOutputPrefixInput(): string | undefined;
+    private _kmsKeyArn?;
+    get kmsKeyArn(): string;
+    set kmsKeyArn(value: string);
+    resetKmsKeyArn(): void;
+    get kmsKeyArnInput(): string | undefined;
+    private _prefix?;
+    get prefix(): string;
+    set prefix(value: string);
+    resetPrefix(): void;
+    get prefixInput(): string | undefined;
+    private _roleArn?;
+    get roleArn(): string;
+    set roleArn(value: string);
+    get roleArnInput(): string | undefined;
+    private _cloudwatchLoggingOptions;
+    get cloudwatchLoggingOptions(): KinesisFirehoseDeliveryStreamSnowflakeConfigurationS3ConfigurationCloudwatchLoggingOptionsOutputReference;
+    putCloudwatchLoggingOptions(value: KinesisFirehoseDeliveryStreamSnowflakeConfigurationS3ConfigurationCloudwatchLoggingOptions): void;
+    resetCloudwatchLoggingOptions(): void;
+    get cloudwatchLoggingOptionsInput(): KinesisFirehoseDeliveryStreamSnowflakeConfigurationS3ConfigurationCloudwatchLoggingOptions | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamSnowflakeConfigurationSecretsManagerConfiguration {
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#enabled KinesisFirehoseDeliveryStream#enabled}
+    */
+    readonly enabled?: boolean | cdktf.IResolvable;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#role_arn KinesisFirehoseDeliveryStream#role_arn}
+    */
+    readonly roleArn?: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#secret_arn KinesisFirehoseDeliveryStream#secret_arn}
+    */
+    readonly secretArn?: string;
+}
+export declare function kinesisFirehoseDeliveryStreamSnowflakeConfigurationSecretsManagerConfigurationToTerraform(struct?: KinesisFirehoseDeliveryStreamSnowflakeConfigurationSecretsManagerConfigurationOutputReference | KinesisFirehoseDeliveryStreamSnowflakeConfigurationSecretsManagerConfiguration): any;
+export declare function kinesisFirehoseDeliveryStreamSnowflakeConfigurationSecretsManagerConfigurationToHclTerraform(struct?: KinesisFirehoseDeliveryStreamSnowflakeConfigurationSecretsManagerConfigurationOutputReference | KinesisFirehoseDeliveryStreamSnowflakeConfigurationSecretsManagerConfiguration): any;
+export declare class KinesisFirehoseDeliveryStreamSnowflakeConfigurationSecretsManagerConfigurationOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamSnowflakeConfigurationSecretsManagerConfiguration | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamSnowflakeConfigurationSecretsManagerConfiguration | undefined);
+    private _enabled?;
+    get enabled(): boolean | cdktf.IResolvable;
+    set enabled(value: boolean | cdktf.IResolvable);
+    resetEnabled(): void;
+    get enabledInput(): boolean | cdktf.IResolvable | undefined;
+    private _roleArn?;
+    get roleArn(): string;
+    set roleArn(value: string);
+    resetRoleArn(): void;
+    get roleArnInput(): string | undefined;
+    private _secretArn?;
+    get secretArn(): string;
+    set secretArn(value: string);
+    resetSecretArn(): void;
+    get secretArnInput(): string | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamSnowflakeConfigurationSnowflakeRoleConfiguration {
+    /** (Optional) Whether the Snowflake role is enabled. */
+    readonly enabled?: boolean | cdktf.IResolvable;
+    /** (Optional) The Snowflake role. */
+    readonly snowflakeRole?: string;
+}
+export declare function kinesisFirehoseDeliveryStreamSnowflakeConfigurationSnowflakeRoleConfigurationToTerraform(struct?: KinesisFirehoseDeliveryStreamSnowflakeConfigurationSnowflakeRoleConfigurationOutputReference | KinesisFirehoseDeliveryStreamSnowflakeConfigurationSnowflakeRoleConfiguration): any;
+export declare function kinesisFirehoseDeliveryStreamSnowflakeConfigurationSnowflakeRoleConfigurationToHclTerraform(struct?: KinesisFirehoseDeliveryStreamSnowflakeConfigurationSnowflakeRoleConfigurationOutputReference | KinesisFirehoseDeliveryStreamSnowflakeConfigurationSnowflakeRoleConfiguration): any;
+export declare class KinesisFirehoseDeliveryStreamSnowflakeConfigurationSnowflakeRoleConfigurationOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamSnowflakeConfigurationSnowflakeRoleConfiguration | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamSnowflakeConfigurationSnowflakeRoleConfiguration | undefined);
+    private _enabled?;
+    get enabled(): boolean | cdktf.IResolvable;
+    set enabled(value: boolean | cdktf.IResolvable);
+    resetEnabled(): void;
+    get enabledInput(): boolean | cdktf.IResolvable | undefined;
+    private _snowflakeRole?;
+    get snowflakeRole(): string;
+    set snowflakeRole(value: string);
+    resetSnowflakeRole(): void;
+    get snowflakeRoleInput(): string | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamSnowflakeConfigurationSnowflakeVpcConfiguration {
+    /** (Required) The VPCE ID for Firehose to privately connect with Snowflake. */
+    readonly privateLinkVpceId: string;
+}
+export declare function kinesisFirehoseDeliveryStreamSnowflakeConfigurationSnowflakeVpcConfigurationToTerraform(struct?: KinesisFirehoseDeliveryStreamSnowflakeConfigurationSnowflakeVpcConfigurationOutputReference | KinesisFirehoseDeliveryStreamSnowflakeConfigurationSnowflakeVpcConfiguration): any;
+export declare function kinesisFirehoseDeliveryStreamSnowflakeConfigurationSnowflakeVpcConfigurationToHclTerraform(struct?: KinesisFirehoseDeliveryStreamSnowflakeConfigurationSnowflakeVpcConfigurationOutputReference | KinesisFirehoseDeliveryStreamSnowflakeConfigurationSnowflakeVpcConfiguration): any;
+export declare class KinesisFirehoseDeliveryStreamSnowflakeConfigurationSnowflakeVpcConfigurationOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamSnowflakeConfigurationSnowflakeVpcConfiguration | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamSnowflakeConfigurationSnowflakeVpcConfiguration | undefined);
+    private _privateLinkVpceId?;
+    get privateLinkVpceId(): string;
+    set privateLinkVpceId(value: string);
+    get privateLinkVpceIdInput(): string | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamSnowflakeConfiguration {
+    /** (Required) The URL of the Snowflake account. Format: https://[account_identifier].snowflakecomputing.com. */
+    readonly accountUrl: string;
+    /** (Optional) Buffer incoming data for the specified period of time, in seconds between 0 to 900, before delivering it to the destination. The default value is 0s. */
+    readonly bufferingInterval?: number;
+    /** (Optional) Buffer incoming data to the specified size, in MBs between 1 to 128, before delivering it to the destination.  The default value is 1MB. */
+    readonly bufferingSize?: number;
+    /** (Optional) The name of the content column. */
+    readonly contentColumnName?: string;
+    /** (Optional) The data loading option. */
+    readonly dataLoadingOption?: string;
+    /** (Required) The Snowflake database name. */
+    readonly database: string;
+    /** (Optional) The passphrase for the private key. */
+    readonly keyPassphrase?: string;
+    /** (Optional) The name of the metadata column. */
+    readonly metadataColumnName?: string;
+    /** (Optional) The private key for authentication. This value is required if `secretsManagerConfiguration` is not provided. */
+    readonly privateKey?: string;
+    /** (Optional) After an initial failure to deliver to Snowflake, the total amount of time, in seconds between 0 to 7200, during which Firehose re-attempts delivery (including the first attempt).  After this time has elapsed, the failed documents are written to Amazon S3.  The default value is 60s.  There will be no retry if the value is 0. */
+    readonly retryDuration?: number;
+    /** (Required) The ARN of the IAM role. */
+    readonly roleArn: string;
+    /** (Optional) Defines how documents should be delivered to Amazon S3.  Valid values are `FailedDataOnly` and `AllData`.  Default value is `FailedDataOnly`. */
+    readonly s3BackupMode?: string;
+    /** (Required) The Snowflake schema name. */
+    readonly schema: string;
+    /** (Required) The Snowflake table name. */
+    readonly table: string;
+    /** (Optional) The user for authentication. This value is required if `secretsManagerConfiguration` is not provided. */
+    readonly user?: string;
+    /** */
+    readonly cloudwatchLoggingOptions?: KinesisFirehoseDeliveryStreamSnowflakeConfigurationCloudwatchLoggingOptions;
+    /** */
+    readonly processingConfiguration?: KinesisFirehoseDeliveryStreamSnowflakeConfigurationProcessingConfiguration;
+    /** */
+    readonly s3Configuration: KinesisFirehoseDeliveryStreamSnowflakeConfigurationS3Configuration;
+    /** */
+    readonly secretsManagerConfiguration?: KinesisFirehoseDeliveryStreamSnowflakeConfigurationSecretsManagerConfiguration;
+    /** */
+    readonly snowflakeRoleConfiguration?: KinesisFirehoseDeliveryStreamSnowflakeConfigurationSnowflakeRoleConfiguration;
+    /** */
+    readonly snowflakeVpcConfiguration?: KinesisFirehoseDeliveryStreamSnowflakeConfigurationSnowflakeVpcConfiguration;
+}
+export declare function kinesisFirehoseDeliveryStreamSnowflakeConfigurationToTerraform(struct?: KinesisFirehoseDeliveryStreamSnowflakeConfigurationOutputReference | KinesisFirehoseDeliveryStreamSnowflakeConfiguration): any;
+export declare function kinesisFirehoseDeliveryStreamSnowflakeConfigurationToHclTerraform(struct?: KinesisFirehoseDeliveryStreamSnowflakeConfigurationOutputReference | KinesisFirehoseDeliveryStreamSnowflakeConfiguration): any;
+export declare class KinesisFirehoseDeliveryStreamSnowflakeConfigurationOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamSnowflakeConfiguration | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamSnowflakeConfiguration | undefined);
+    private _accountUrl?;
+    get accountUrl(): string;
+    set accountUrl(value: string);
+    get accountUrlInput(): string | undefined;
+    private _bufferingInterval?;
+    get bufferingInterval(): number;
+    set bufferingInterval(value: number);
+    resetBufferingInterval(): void;
+    get bufferingIntervalInput(): number | undefined;
+    private _bufferingSize?;
+    get bufferingSize(): number;
+    set bufferingSize(value: number);
+    resetBufferingSize(): void;
+    get bufferingSizeInput(): number | undefined;
+    private _contentColumnName?;
+    get contentColumnName(): string;
+    set contentColumnName(value: string);
+    resetContentColumnName(): void;
+    get contentColumnNameInput(): string | undefined;
+    private _dataLoadingOption?;
+    get dataLoadingOption(): string;
+    set dataLoadingOption(value: string);
+    resetDataLoadingOption(): void;
+    get dataLoadingOptionInput(): string | undefined;
+    private _database?;
+    get database(): string;
+    set database(value: string);
+    get databaseInput(): string | undefined;
+    private _keyPassphrase?;
+    get keyPassphrase(): string;
+    set keyPassphrase(value: string);
+    resetKeyPassphrase(): void;
+    get keyPassphraseInput(): string | undefined;
+    private _metadataColumnName?;
+    get metadataColumnName(): string;
+    set metadataColumnName(value: string);
+    resetMetadataColumnName(): void;
+    get metadataColumnNameInput(): string | undefined;
+    private _privateKey?;
+    get privateKey(): string;
+    set privateKey(value: string);
+    resetPrivateKey(): void;
+    get privateKeyInput(): string | undefined;
+    private _retryDuration?;
+    get retryDuration(): number;
+    set retryDuration(value: number);
+    resetRetryDuration(): void;
+    get retryDurationInput(): number | undefined;
+    private _roleArn?;
+    get roleArn(): string;
+    set roleArn(value: string);
+    get roleArnInput(): string | undefined;
+    private _s3BackupMode?;
+    get s3BackupMode(): string;
+    set s3BackupMode(value: string);
+    resetS3BackupMode(): void;
+    get s3BackupModeInput(): string | undefined;
+    private _schema?;
+    get schema(): string;
+    set schema(value: string);
+    get schemaInput(): string | undefined;
+    private _table?;
+    get table(): string;
+    set table(value: string);
+    get tableInput(): string | undefined;
+    private _user?;
+    get user(): string;
+    set user(value: string);
+    resetUser(): void;
+    get userInput(): string | undefined;
+    private _cloudwatchLoggingOptions;
+    get cloudwatchLoggingOptions(): KinesisFirehoseDeliveryStreamSnowflakeConfigurationCloudwatchLoggingOptionsOutputReference;
+    putCloudwatchLoggingOptions(value: KinesisFirehoseDeliveryStreamSnowflakeConfigurationCloudwatchLoggingOptions): void;
+    resetCloudwatchLoggingOptions(): void;
+    get cloudwatchLoggingOptionsInput(): KinesisFirehoseDeliveryStreamSnowflakeConfigurationCloudwatchLoggingOptions | undefined;
+    private _processingConfiguration;
+    get processingConfiguration(): KinesisFirehoseDeliveryStreamSnowflakeConfigurationProcessingConfigurationOutputReference;
+    putProcessingConfiguration(value: KinesisFirehoseDeliveryStreamSnowflakeConfigurationProcessingConfiguration): void;
+    resetProcessingConfiguration(): void;
+    get processingConfigurationInput(): KinesisFirehoseDeliveryStreamSnowflakeConfigurationProcessingConfiguration | undefined;
+    private _s3Configuration;
+    get s3Configuration(): KinesisFirehoseDeliveryStreamSnowflakeConfigurationS3ConfigurationOutputReference;
+    putS3Configuration(value: KinesisFirehoseDeliveryStreamSnowflakeConfigurationS3Configuration): void;
+    get s3ConfigurationInput(): KinesisFirehoseDeliveryStreamSnowflakeConfigurationS3Configuration | undefined;
+    private _secretsManagerConfiguration;
+    get secretsManagerConfiguration(): KinesisFirehoseDeliveryStreamSnowflakeConfigurationSecretsManagerConfigurationOutputReference;
+    putSecretsManagerConfiguration(value: KinesisFirehoseDeliveryStreamSnowflakeConfigurationSecretsManagerConfiguration): void;
+    resetSecretsManagerConfiguration(): void;
+    get secretsManagerConfigurationInput(): KinesisFirehoseDeliveryStreamSnowflakeConfigurationSecretsManagerConfiguration | undefined;
+    private _snowflakeRoleConfiguration;
+    get snowflakeRoleConfiguration(): KinesisFirehoseDeliveryStreamSnowflakeConfigurationSnowflakeRoleConfigurationOutputReference;
+    putSnowflakeRoleConfiguration(value: KinesisFirehoseDeliveryStreamSnowflakeConfigurationSnowflakeRoleConfiguration): void;
+    resetSnowflakeRoleConfiguration(): void;
+    get snowflakeRoleConfigurationInput(): KinesisFirehoseDeliveryStreamSnowflakeConfigurationSnowflakeRoleConfiguration | undefined;
+    private _snowflakeVpcConfiguration;
+    get snowflakeVpcConfiguration(): KinesisFirehoseDeliveryStreamSnowflakeConfigurationSnowflakeVpcConfigurationOutputReference;
+    putSnowflakeVpcConfiguration(value: KinesisFirehoseDeliveryStreamSnowflakeConfigurationSnowflakeVpcConfiguration): void;
+    resetSnowflakeVpcConfiguration(): void;
+    get snowflakeVpcConfigurationInput(): KinesisFirehoseDeliveryStreamSnowflakeConfigurationSnowflakeVpcConfiguration | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamSplunkConfigurationCloudwatchLoggingOptions {
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#enabled KinesisFirehoseDeliveryStream#enabled}
+    */
+    readonly enabled?: boolean | cdktf.IResolvable;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#log_group_name KinesisFirehoseDeliveryStream#log_group_name}
+    */
+    readonly logGroupName?: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#log_stream_name KinesisFirehoseDeliveryStream#log_stream_name}
+    */
+    readonly logStreamName?: string;
+}
+export declare function kinesisFirehoseDeliveryStreamSplunkConfigurationCloudwatchLoggingOptionsToTerraform(struct?: KinesisFirehoseDeliveryStreamSplunkConfigurationCloudwatchLoggingOptionsOutputReference | KinesisFirehoseDeliveryStreamSplunkConfigurationCloudwatchLoggingOptions): any;
+export declare function kinesisFirehoseDeliveryStreamSplunkConfigurationCloudwatchLoggingOptionsToHclTerraform(struct?: KinesisFirehoseDeliveryStreamSplunkConfigurationCloudwatchLoggingOptionsOutputReference | KinesisFirehoseDeliveryStreamSplunkConfigurationCloudwatchLoggingOptions): any;
+export declare class KinesisFirehoseDeliveryStreamSplunkConfigurationCloudwatchLoggingOptionsOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamSplunkConfigurationCloudwatchLoggingOptions | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamSplunkConfigurationCloudwatchLoggingOptions | undefined);
+    private _enabled?;
+    get enabled(): boolean | cdktf.IResolvable;
+    set enabled(value: boolean | cdktf.IResolvable);
+    resetEnabled(): void;
+    get enabledInput(): boolean | cdktf.IResolvable | undefined;
+    private _logGroupName?;
+    get logGroupName(): string;
+    set logGroupName(value: string);
+    resetLogGroupName(): void;
+    get logGroupNameInput(): string | undefined;
+    private _logStreamName?;
+    get logStreamName(): string;
+    set logStreamName(value: string);
+    resetLogStreamName(): void;
+    get logStreamNameInput(): string | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamSplunkConfigurationProcessingConfigurationProcessorsParameters {
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#parameter_name KinesisFirehoseDeliveryStream#parameter_name}
+    */
+    readonly parameterName: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#parameter_value KinesisFirehoseDeliveryStream#parameter_value}
+    */
+    readonly parameterValue: string;
+}
+export declare function kinesisFirehoseDeliveryStreamSplunkConfigurationProcessingConfigurationProcessorsParametersToTerraform(struct?: KinesisFirehoseDeliveryStreamSplunkConfigurationProcessingConfigurationProcessorsParameters | cdktf.IResolvable): any;
+export declare function kinesisFirehoseDeliveryStreamSplunkConfigurationProcessingConfigurationProcessorsParametersToHclTerraform(struct?: KinesisFirehoseDeliveryStreamSplunkConfigurationProcessingConfigurationProcessorsParameters | cdktf.IResolvable): any;
+export declare class KinesisFirehoseDeliveryStreamSplunkConfigurationProcessingConfigurationProcessorsParametersOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    private resolvableValue?;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    * @param complexObjectIndex the index of this item in the list
+    * @param complexObjectIsFromSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string, complexObjectIndex: number, complexObjectIsFromSet: boolean);
+    get internalValue(): KinesisFirehoseDeliveryStreamSplunkConfigurationProcessingConfigurationProcessorsParameters | cdktf.IResolvable | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamSplunkConfigurationProcessingConfigurationProcessorsParameters | cdktf.IResolvable | undefined);
+    private _parameterName?;
+    get parameterName(): string;
+    set parameterName(value: string);
+    get parameterNameInput(): string | undefined;
+    private _parameterValue?;
+    get parameterValue(): string;
+    set parameterValue(value: string);
+    get parameterValueInput(): string | undefined;
+}
+export declare class KinesisFirehoseDeliveryStreamSplunkConfigurationProcessingConfigurationProcessorsParametersList extends cdktf.ComplexList {
+    protected terraformResource: cdktf.IInterpolatingParent;
+    protected terraformAttribute: string;
+    protected wrapsSet: boolean;
+    internalValue?: KinesisFirehoseDeliveryStreamSplunkConfigurationProcessingConfigurationProcessorsParameters[] | cdktf.IResolvable;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    * @param wrapsSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string, wrapsSet: boolean);
+    /**
+    * @param index the index of the item to return
+    */
+    get(index: number): KinesisFirehoseDeliveryStreamSplunkConfigurationProcessingConfigurationProcessorsParametersOutputReference;
+}
+export interface KinesisFirehoseDeliveryStreamSplunkConfigurationProcessingConfigurationProcessors {
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#type KinesisFirehoseDeliveryStream#type}
+    */
+    readonly type: string;
+    /**
+    * parameters block
+    *
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#parameters KinesisFirehoseDeliveryStream#parameters}
+    */
+    readonly parameters?: KinesisFirehoseDeliveryStreamSplunkConfigurationProcessingConfigurationProcessorsParameters[] | cdktf.IResolvable;
+}
+export declare function kinesisFirehoseDeliveryStreamSplunkConfigurationProcessingConfigurationProcessorsToTerraform(struct?: KinesisFirehoseDeliveryStreamSplunkConfigurationProcessingConfigurationProcessors | cdktf.IResolvable): any;
+export declare function kinesisFirehoseDeliveryStreamSplunkConfigurationProcessingConfigurationProcessorsToHclTerraform(struct?: KinesisFirehoseDeliveryStreamSplunkConfigurationProcessingConfigurationProcessors | cdktf.IResolvable): any;
+export declare class KinesisFirehoseDeliveryStreamSplunkConfigurationProcessingConfigurationProcessorsOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    private resolvableValue?;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    * @param complexObjectIndex the index of this item in the list
+    * @param complexObjectIsFromSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string, complexObjectIndex: number, complexObjectIsFromSet: boolean);
+    get internalValue(): KinesisFirehoseDeliveryStreamSplunkConfigurationProcessingConfigurationProcessors | cdktf.IResolvable | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamSplunkConfigurationProcessingConfigurationProcessors | cdktf.IResolvable | undefined);
+    private _type?;
+    get type(): string;
+    set type(value: string);
+    get typeInput(): string | undefined;
+    private _parameters;
+    get parameters(): KinesisFirehoseDeliveryStreamSplunkConfigurationProcessingConfigurationProcessorsParametersList;
+    putParameters(value: KinesisFirehoseDeliveryStreamSplunkConfigurationProcessingConfigurationProcessorsParameters[] | cdktf.IResolvable): void;
+    resetParameters(): void;
+    get parametersInput(): cdktf.IResolvable | KinesisFirehoseDeliveryStreamSplunkConfigurationProcessingConfigurationProcessorsParameters[] | undefined;
+}
+export declare class KinesisFirehoseDeliveryStreamSplunkConfigurationProcessingConfigurationProcessorsList extends cdktf.ComplexList {
+    protected terraformResource: cdktf.IInterpolatingParent;
+    protected terraformAttribute: string;
+    protected wrapsSet: boolean;
+    internalValue?: KinesisFirehoseDeliveryStreamSplunkConfigurationProcessingConfigurationProcessors[] | cdktf.IResolvable;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    * @param wrapsSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string, wrapsSet: boolean);
+    /**
+    * @param index the index of the item to return
+    */
+    get(index: number): KinesisFirehoseDeliveryStreamSplunkConfigurationProcessingConfigurationProcessorsOutputReference;
+}
+export interface KinesisFirehoseDeliveryStreamSplunkConfigurationProcessingConfiguration {
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#enabled KinesisFirehoseDeliveryStream#enabled}
+    */
+    readonly enabled?: boolean | cdktf.IResolvable;
+    /**
+    * processors block
+    *
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#processors KinesisFirehoseDeliveryStream#processors}
+    */
+    readonly processors?: KinesisFirehoseDeliveryStreamSplunkConfigurationProcessingConfigurationProcessors[] | cdktf.IResolvable;
+}
+export declare function kinesisFirehoseDeliveryStreamSplunkConfigurationProcessingConfigurationToTerraform(struct?: KinesisFirehoseDeliveryStreamSplunkConfigurationProcessingConfigurationOutputReference | KinesisFirehoseDeliveryStreamSplunkConfigurationProcessingConfiguration): any;
+export declare function kinesisFirehoseDeliveryStreamSplunkConfigurationProcessingConfigurationToHclTerraform(struct?: KinesisFirehoseDeliveryStreamSplunkConfigurationProcessingConfigurationOutputReference | KinesisFirehoseDeliveryStreamSplunkConfigurationProcessingConfiguration): any;
+export declare class KinesisFirehoseDeliveryStreamSplunkConfigurationProcessingConfigurationOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamSplunkConfigurationProcessingConfiguration | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamSplunkConfigurationProcessingConfiguration | undefined);
+    private _enabled?;
+    get enabled(): boolean | cdktf.IResolvable;
+    set enabled(value: boolean | cdktf.IResolvable);
+    resetEnabled(): void;
+    get enabledInput(): boolean | cdktf.IResolvable | undefined;
+    private _processors;
+    get processors(): KinesisFirehoseDeliveryStreamSplunkConfigurationProcessingConfigurationProcessorsList;
+    putProcessors(value: KinesisFirehoseDeliveryStreamSplunkConfigurationProcessingConfigurationProcessors[] | cdktf.IResolvable): void;
+    resetProcessors(): void;
+    get processorsInput(): cdktf.IResolvable | KinesisFirehoseDeliveryStreamSplunkConfigurationProcessingConfigurationProcessors[] | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamSplunkConfigurationS3ConfigurationCloudwatchLoggingOptions {
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#enabled KinesisFirehoseDeliveryStream#enabled}
+    */
+    readonly enabled?: boolean | cdktf.IResolvable;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#log_group_name KinesisFirehoseDeliveryStream#log_group_name}
+    */
+    readonly logGroupName?: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#log_stream_name KinesisFirehoseDeliveryStream#log_stream_name}
+    */
+    readonly logStreamName?: string;
+}
+export declare function kinesisFirehoseDeliveryStreamSplunkConfigurationS3ConfigurationCloudwatchLoggingOptionsToTerraform(struct?: KinesisFirehoseDeliveryStreamSplunkConfigurationS3ConfigurationCloudwatchLoggingOptionsOutputReference | KinesisFirehoseDeliveryStreamSplunkConfigurationS3ConfigurationCloudwatchLoggingOptions): any;
+export declare function kinesisFirehoseDeliveryStreamSplunkConfigurationS3ConfigurationCloudwatchLoggingOptionsToHclTerraform(struct?: KinesisFirehoseDeliveryStreamSplunkConfigurationS3ConfigurationCloudwatchLoggingOptionsOutputReference | KinesisFirehoseDeliveryStreamSplunkConfigurationS3ConfigurationCloudwatchLoggingOptions): any;
+export declare class KinesisFirehoseDeliveryStreamSplunkConfigurationS3ConfigurationCloudwatchLoggingOptionsOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamSplunkConfigurationS3ConfigurationCloudwatchLoggingOptions | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamSplunkConfigurationS3ConfigurationCloudwatchLoggingOptions | undefined);
+    private _enabled?;
+    get enabled(): boolean | cdktf.IResolvable;
+    set enabled(value: boolean | cdktf.IResolvable);
+    resetEnabled(): void;
+    get enabledInput(): boolean | cdktf.IResolvable | undefined;
+    private _logGroupName?;
+    get logGroupName(): string;
+    set logGroupName(value: string);
+    resetLogGroupName(): void;
+    get logGroupNameInput(): string | undefined;
+    private _logStreamName?;
+    get logStreamName(): string;
+    set logStreamName(value: string);
+    resetLogStreamName(): void;
+    get logStreamNameInput(): string | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamSplunkConfigurationS3Configuration {
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#bucket_arn KinesisFirehoseDeliveryStream#bucket_arn}
+    */
+    readonly bucketArn: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#buffering_interval KinesisFirehoseDeliveryStream#buffering_interval}
+    */
+    readonly bufferingInterval?: number;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#buffering_size KinesisFirehoseDeliveryStream#buffering_size}
+    */
+    readonly bufferingSize?: number;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#compression_format KinesisFirehoseDeliveryStream#compression_format}
+    */
+    readonly compressionFormat?: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#error_output_prefix KinesisFirehoseDeliveryStream#error_output_prefix}
+    */
+    readonly errorOutputPrefix?: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#kms_key_arn KinesisFirehoseDeliveryStream#kms_key_arn}
+    */
+    readonly kmsKeyArn?: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#prefix KinesisFirehoseDeliveryStream#prefix}
+    */
+    readonly prefix?: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#role_arn KinesisFirehoseDeliveryStream#role_arn}
+    */
+    readonly roleArn: string;
+    /**
+    * cloudwatch_logging_options block
+    *
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#cloudwatch_logging_options KinesisFirehoseDeliveryStream#cloudwatch_logging_options}
+    */
+    readonly cloudwatchLoggingOptions?: KinesisFirehoseDeliveryStreamSplunkConfigurationS3ConfigurationCloudwatchLoggingOptions;
+}
+export declare function kinesisFirehoseDeliveryStreamSplunkConfigurationS3ConfigurationToTerraform(struct?: KinesisFirehoseDeliveryStreamSplunkConfigurationS3ConfigurationOutputReference | KinesisFirehoseDeliveryStreamSplunkConfigurationS3Configuration): any;
+export declare function kinesisFirehoseDeliveryStreamSplunkConfigurationS3ConfigurationToHclTerraform(struct?: KinesisFirehoseDeliveryStreamSplunkConfigurationS3ConfigurationOutputReference | KinesisFirehoseDeliveryStreamSplunkConfigurationS3Configuration): any;
+export declare class KinesisFirehoseDeliveryStreamSplunkConfigurationS3ConfigurationOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamSplunkConfigurationS3Configuration | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamSplunkConfigurationS3Configuration | undefined);
+    private _bucketArn?;
+    get bucketArn(): string;
+    set bucketArn(value: string);
+    get bucketArnInput(): string | undefined;
+    private _bufferingInterval?;
+    get bufferingInterval(): number;
+    set bufferingInterval(value: number);
+    resetBufferingInterval(): void;
+    get bufferingIntervalInput(): number | undefined;
+    private _bufferingSize?;
+    get bufferingSize(): number;
+    set bufferingSize(value: number);
+    resetBufferingSize(): void;
+    get bufferingSizeInput(): number | undefined;
+    private _compressionFormat?;
+    get compressionFormat(): string;
+    set compressionFormat(value: string);
+    resetCompressionFormat(): void;
+    get compressionFormatInput(): string | undefined;
+    private _errorOutputPrefix?;
+    get errorOutputPrefix(): string;
+    set errorOutputPrefix(value: string);
+    resetErrorOutputPrefix(): void;
+    get errorOutputPrefixInput(): string | undefined;
+    private _kmsKeyArn?;
+    get kmsKeyArn(): string;
+    set kmsKeyArn(value: string);
+    resetKmsKeyArn(): void;
+    get kmsKeyArnInput(): string | undefined;
+    private _prefix?;
+    get prefix(): string;
+    set prefix(value: string);
+    resetPrefix(): void;
+    get prefixInput(): string | undefined;
+    private _roleArn?;
+    get roleArn(): string;
+    set roleArn(value: string);
+    get roleArnInput(): string | undefined;
+    private _cloudwatchLoggingOptions;
+    get cloudwatchLoggingOptions(): KinesisFirehoseDeliveryStreamSplunkConfigurationS3ConfigurationCloudwatchLoggingOptionsOutputReference;
+    putCloudwatchLoggingOptions(value: KinesisFirehoseDeliveryStreamSplunkConfigurationS3ConfigurationCloudwatchLoggingOptions): void;
+    resetCloudwatchLoggingOptions(): void;
+    get cloudwatchLoggingOptionsInput(): KinesisFirehoseDeliveryStreamSplunkConfigurationS3ConfigurationCloudwatchLoggingOptions | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamSplunkConfigurationSecretsManagerConfiguration {
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#enabled KinesisFirehoseDeliveryStream#enabled}
+    */
+    readonly enabled?: boolean | cdktf.IResolvable;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#role_arn KinesisFirehoseDeliveryStream#role_arn}
+    */
+    readonly roleArn?: string;
+    /**
+    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#secret_arn KinesisFirehoseDeliveryStream#secret_arn}
+    */
+    readonly secretArn?: string;
+}
+export declare function kinesisFirehoseDeliveryStreamSplunkConfigurationSecretsManagerConfigurationToTerraform(struct?: KinesisFirehoseDeliveryStreamSplunkConfigurationSecretsManagerConfigurationOutputReference | KinesisFirehoseDeliveryStreamSplunkConfigurationSecretsManagerConfiguration): any;
+export declare function kinesisFirehoseDeliveryStreamSplunkConfigurationSecretsManagerConfigurationToHclTerraform(struct?: KinesisFirehoseDeliveryStreamSplunkConfigurationSecretsManagerConfigurationOutputReference | KinesisFirehoseDeliveryStreamSplunkConfigurationSecretsManagerConfiguration): any;
+export declare class KinesisFirehoseDeliveryStreamSplunkConfigurationSecretsManagerConfigurationOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamSplunkConfigurationSecretsManagerConfiguration | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamSplunkConfigurationSecretsManagerConfiguration | undefined);
+    private _enabled?;
+    get enabled(): boolean | cdktf.IResolvable;
+    set enabled(value: boolean | cdktf.IResolvable);
+    resetEnabled(): void;
+    get enabledInput(): boolean | cdktf.IResolvable | undefined;
+    private _roleArn?;
+    get roleArn(): string;
+    set roleArn(value: string);
+    resetRoleArn(): void;
+    get roleArnInput(): string | undefined;
+    private _secretArn?;
+    get secretArn(): string;
+    set secretArn(value: string);
+    resetSecretArn(): void;
+    get secretArnInput(): string | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamSplunkConfiguration {
+    /** (Optional) Buffer incoming data for the specified period of time, in seconds between 0 to 60, before delivering it to the destination.  The default value is 60s. */
+    readonly bufferingInterval?: number;
+    /** (Optional) Buffer incoming data to the specified size, in MBs between 1 to 5, before delivering it to the destination.  The default value is 5MB. */
+    readonly bufferingSize?: number;
+    /** (Optional) The amount of time, in seconds between 180 and 600, that Kinesis Firehose waits to receive an acknowledgment from Splunk after it sends it data. */
+    readonly hecAcknowledgmentTimeout?: number;
+    /** (Required) The HTTP Event Collector (HEC) endpoint to which Kinesis Firehose sends your data. */
+    readonly hecEndpoint: string;
+    /** (Optional) The HEC endpoint type. Valid values are `Raw` or `Event`. The default value is `Raw`. */
+    readonly hecEndpointType?: string;
+    /** (Optional) The GUID that you obtain from your Splunk cluster when you create a new HEC endpoint. This value is required if `secretsManagerConfiguration` is not provided. */
+    readonly hecToken?: string;
+    /** (Optional) After an initial failure to deliver to Splunk, the total amount of time, in seconds between 0 to 7200, during which Firehose re-attempts delivery (including the first attempt).  After this time has elapsed, the failed documents are written to Amazon S3.  The default value is 300s.  There will be no retry if the value is 0. */
+    readonly retryDuration?: number;
+    /** (Optional) Defines how documents should be delivered to Amazon S3.  Valid values are `FailedEventsOnly` and `AllEvents`.  Default value is `FailedEventsOnly`. */
+    readonly s3BackupMode?: string;
+    /** */
+    readonly cloudwatchLoggingOptions?: KinesisFirehoseDeliveryStreamSplunkConfigurationCloudwatchLoggingOptions;
+    /** */
+    readonly processingConfiguration?: KinesisFirehoseDeliveryStreamSplunkConfigurationProcessingConfiguration;
+    /** */
+    readonly s3Configuration: KinesisFirehoseDeliveryStreamSplunkConfigurationS3Configuration;
+    /** */
+    readonly secretsManagerConfiguration?: KinesisFirehoseDeliveryStreamSplunkConfigurationSecretsManagerConfiguration;
+}
+export declare function kinesisFirehoseDeliveryStreamSplunkConfigurationToTerraform(struct?: KinesisFirehoseDeliveryStreamSplunkConfigurationOutputReference | KinesisFirehoseDeliveryStreamSplunkConfiguration): any;
+export declare function kinesisFirehoseDeliveryStreamSplunkConfigurationToHclTerraform(struct?: KinesisFirehoseDeliveryStreamSplunkConfigurationOutputReference | KinesisFirehoseDeliveryStreamSplunkConfiguration): any;
+export declare class KinesisFirehoseDeliveryStreamSplunkConfigurationOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamSplunkConfiguration | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamSplunkConfiguration | undefined);
+    private _bufferingInterval?;
+    get bufferingInterval(): number;
+    set bufferingInterval(value: number);
+    resetBufferingInterval(): void;
+    get bufferingIntervalInput(): number | undefined;
+    private _bufferingSize?;
+    get bufferingSize(): number;
+    set bufferingSize(value: number);
+    resetBufferingSize(): void;
+    get bufferingSizeInput(): number | undefined;
+    private _hecAcknowledgmentTimeout?;
+    get hecAcknowledgmentTimeout(): number;
+    set hecAcknowledgmentTimeout(value: number);
+    resetHecAcknowledgmentTimeout(): void;
+    get hecAcknowledgmentTimeoutInput(): number | undefined;
+    private _hecEndpoint?;
+    get hecEndpoint(): string;
+    set hecEndpoint(value: string);
+    get hecEndpointInput(): string | undefined;
+    private _hecEndpointType?;
+    get hecEndpointType(): string;
+    set hecEndpointType(value: string);
+    resetHecEndpointType(): void;
+    get hecEndpointTypeInput(): string | undefined;
+    private _hecToken?;
+    get hecToken(): string;
+    set hecToken(value: string);
+    resetHecToken(): void;
+    get hecTokenInput(): string | undefined;
+    private _retryDuration?;
+    get retryDuration(): number;
+    set retryDuration(value: number);
+    resetRetryDuration(): void;
+    get retryDurationInput(): number | undefined;
+    private _s3BackupMode?;
+    get s3BackupMode(): string;
+    set s3BackupMode(value: string);
+    resetS3BackupMode(): void;
+    get s3BackupModeInput(): string | undefined;
+    private _cloudwatchLoggingOptions;
+    get cloudwatchLoggingOptions(): KinesisFirehoseDeliveryStreamSplunkConfigurationCloudwatchLoggingOptionsOutputReference;
+    putCloudwatchLoggingOptions(value: KinesisFirehoseDeliveryStreamSplunkConfigurationCloudwatchLoggingOptions): void;
+    resetCloudwatchLoggingOptions(): void;
+    get cloudwatchLoggingOptionsInput(): KinesisFirehoseDeliveryStreamSplunkConfigurationCloudwatchLoggingOptions | undefined;
+    private _processingConfiguration;
+    get processingConfiguration(): KinesisFirehoseDeliveryStreamSplunkConfigurationProcessingConfigurationOutputReference;
+    putProcessingConfiguration(value: KinesisFirehoseDeliveryStreamSplunkConfigurationProcessingConfiguration): void;
+    resetProcessingConfiguration(): void;
+    get processingConfigurationInput(): KinesisFirehoseDeliveryStreamSplunkConfigurationProcessingConfiguration | undefined;
+    private _s3Configuration;
+    get s3Configuration(): KinesisFirehoseDeliveryStreamSplunkConfigurationS3ConfigurationOutputReference;
+    putS3Configuration(value: KinesisFirehoseDeliveryStreamSplunkConfigurationS3Configuration): void;
+    get s3ConfigurationInput(): KinesisFirehoseDeliveryStreamSplunkConfigurationS3Configuration | undefined;
+    private _secretsManagerConfiguration;
+    get secretsManagerConfiguration(): KinesisFirehoseDeliveryStreamSplunkConfigurationSecretsManagerConfigurationOutputReference;
+    putSecretsManagerConfiguration(value: KinesisFirehoseDeliveryStreamSplunkConfigurationSecretsManagerConfiguration): void;
+    resetSecretsManagerConfiguration(): void;
+    get secretsManagerConfigurationInput(): KinesisFirehoseDeliveryStreamSplunkConfigurationSecretsManagerConfiguration | undefined;
+}
+export interface KinesisFirehoseDeliveryStreamTimeouts {
+    /** (Default `30m`) */
+    readonly create?: string;
+    /** (Default `30m`) */
+    readonly delete?: string;
+    /** (Default `10m`) */
+    readonly update?: string;
+}
+export declare function kinesisFirehoseDeliveryStreamTimeoutsToTerraform(struct?: KinesisFirehoseDeliveryStreamTimeouts | cdktf.IResolvable): any;
+export declare function kinesisFirehoseDeliveryStreamTimeoutsToHclTerraform(struct?: KinesisFirehoseDeliveryStreamTimeouts | cdktf.IResolvable): any;
+export declare class KinesisFirehoseDeliveryStreamTimeoutsOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    private resolvableValue?;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): KinesisFirehoseDeliveryStreamTimeouts | cdktf.IResolvable | undefined;
+    set internalValue(value: KinesisFirehoseDeliveryStreamTimeouts | cdktf.IResolvable | undefined);
+    private _create?;
+    get create(): string;
+    set create(value: string);
+    resetCreate(): void;
+    get createInput(): string | undefined;
+    private _delete?;
+    get delete(): string;
+    set delete(value: string);
+    resetDelete(): void;
+    get deleteInput(): string | undefined;
+    private _update?;
+    get update(): string;
+    set update(value: string);
+    resetUpdate(): void;
+    get updateInput(): string | undefined;
+}
+/**
+* Represents a {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream aws_kinesis_firehose_delivery_stream}
+*/
+export declare class KinesisFirehoseDeliveryStream extends cdktf.TerraformResource {
+    static readonly tfResourceType = "aws_kinesis_firehose_delivery_stream";
+    /**
+    * Generates CDKTF code for importing a KinesisFirehoseDeliveryStream resource upon running "cdktf plan <stack-name>"
+    * @param scope The scope in which to define this construct
+    * @param importToId The construct id used in the generated config for the KinesisFirehoseDeliveryStream to import
+    * @param importFromId The id of the existing KinesisFirehoseDeliveryStream that should be imported. Refer to the {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream#import import section} in the documentation of this resource for the id to use
+    * @param provider? Optional instance of the provider where the KinesisFirehoseDeliveryStream to import is found
+    */
+    static generateConfigForImport(scope: Construct, importToId: string, importFromId: string, provider?: cdktf.TerraformProvider): cdktf.ImportableResource;
+    /**
+    * Create a new {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/kinesis_firehose_delivery_stream aws_kinesis_firehose_delivery_stream} Resource
+    *
+    * @param scope The scope in which to define this construct
+    * @param id The scoped construct ID. Must be unique amongst siblings in the same scope
+    * @param options KinesisFirehoseDeliveryStreamConfig
+    */
+    constructor(scope: Construct, id: string, config: KinesisFirehoseDeliveryStreamConfig);
+    private _arn?;
+    get arn(): string;
+    set arn(value: string);
+    resetArn(): void;
+    get arnInput(): string | undefined;
+    private _destination?;
+    get destination(): string;
+    set destination(value: string);
+    get destinationInput(): string | undefined;
+    private _destinationId?;
+    get destinationId(): string;
+    set destinationId(value: string);
+    resetDestinationId(): void;
+    get destinationIdInput(): string | undefined;
+    private _id?;
+    get id(): string;
+    set id(value: string);
+    resetId(): void;
+    get idInput(): string | undefined;
+    private _name?;
+    get name(): string;
+    set name(value: string);
+    get nameInput(): string | undefined;
+    private _tags?;
+    get tags(): {
+        [key: string]: string;
+    };
+    set tags(value: {
+        [key: string]: string;
+    });
+    resetTags(): void;
+    get tagsInput(): {
+        [key: string]: string;
+    } | undefined;
+    private _tagsAll?;
+    get tagsAll(): {
+        [key: string]: string;
+    };
+    set tagsAll(value: {
+        [key: string]: string;
+    });
+    resetTagsAll(): void;
+    get tagsAllInput(): {
+        [key: string]: string;
+    } | undefined;
+    private _versionId?;
+    get versionId(): string;
+    set versionId(value: string);
+    resetVersionId(): void;
+    get versionIdInput(): string | undefined;
+    private _elasticsearchConfiguration;
+    get elasticsearchConfiguration(): KinesisFirehoseDeliveryStreamElasticsearchConfigurationOutputReference;
+    putElasticsearchConfiguration(value: KinesisFirehoseDeliveryStreamElasticsearchConfiguration): void;
+    resetElasticsearchConfiguration(): void;
+    get elasticsearchConfigurationInput(): KinesisFirehoseDeliveryStreamElasticsearchConfiguration | undefined;
+    private _extendedS3Configuration;
+    get extendedS3Configuration(): KinesisFirehoseDeliveryStreamExtendedS3ConfigurationOutputReference;
+    putExtendedS3Configuration(value: KinesisFirehoseDeliveryStreamExtendedS3Configuration): void;
+    resetExtendedS3Configuration(): void;
+    get extendedS3ConfigurationInput(): KinesisFirehoseDeliveryStreamExtendedS3Configuration | undefined;
+    private _httpEndpointConfiguration;
+    get httpEndpointConfiguration(): KinesisFirehoseDeliveryStreamHttpEndpointConfigurationOutputReference;
+    putHttpEndpointConfiguration(value: KinesisFirehoseDeliveryStreamHttpEndpointConfiguration): void;
+    resetHttpEndpointConfiguration(): void;
+    get httpEndpointConfigurationInput(): KinesisFirehoseDeliveryStreamHttpEndpointConfiguration | undefined;
+    private _icebergConfiguration;
+    get icebergConfiguration(): KinesisFirehoseDeliveryStreamIcebergConfigurationOutputReference;
+    putIcebergConfiguration(value: KinesisFirehoseDeliveryStreamIcebergConfiguration): void;
+    resetIcebergConfiguration(): void;
+    get icebergConfigurationInput(): KinesisFirehoseDeliveryStreamIcebergConfiguration | undefined;
+    private _kinesisSourceConfiguration;
+    get kinesisSourceConfiguration(): KinesisFirehoseDeliveryStreamKinesisSourceConfigurationOutputReference;
+    putKinesisSourceConfiguration(value: KinesisFirehoseDeliveryStreamKinesisSourceConfiguration): void;
+    resetKinesisSourceConfiguration(): void;
+    get kinesisSourceConfigurationInput(): KinesisFirehoseDeliveryStreamKinesisSourceConfiguration | undefined;
+    private _mskSourceConfiguration;
+    get mskSourceConfiguration(): KinesisFirehoseDeliveryStreamMskSourceConfigurationOutputReference;
+    putMskSourceConfiguration(value: KinesisFirehoseDeliveryStreamMskSourceConfiguration): void;
+    resetMskSourceConfiguration(): void;
+    get mskSourceConfigurationInput(): KinesisFirehoseDeliveryStreamMskSourceConfiguration | undefined;
+    private _opensearchConfiguration;
+    get opensearchConfiguration(): KinesisFirehoseDeliveryStreamOpensearchConfigurationOutputReference;
+    putOpensearchConfiguration(value: KinesisFirehoseDeliveryStreamOpensearchConfiguration): void;
+    resetOpensearchConfiguration(): void;
+    get opensearchConfigurationInput(): KinesisFirehoseDeliveryStreamOpensearchConfiguration | undefined;
+    private _opensearchserverlessConfiguration;
+    get opensearchserverlessConfiguration(): KinesisFirehoseDeliveryStreamOpensearchserverlessConfigurationOutputReference;
+    putOpensearchserverlessConfiguration(value: KinesisFirehoseDeliveryStreamOpensearchserverlessConfiguration): void;
+    resetOpensearchserverlessConfiguration(): void;
+    get opensearchserverlessConfigurationInput(): KinesisFirehoseDeliveryStreamOpensearchserverlessConfiguration | undefined;
+    private _redshiftConfiguration;
+    get redshiftConfiguration(): KinesisFirehoseDeliveryStreamRedshiftConfigurationOutputReference;
+    putRedshiftConfiguration(value: KinesisFirehoseDeliveryStreamRedshiftConfiguration): void;
+    resetRedshiftConfiguration(): void;
+    get redshiftConfigurationInput(): KinesisFirehoseDeliveryStreamRedshiftConfiguration | undefined;
+    private _serverSideEncryption;
+    get serverSideEncryption(): KinesisFirehoseDeliveryStreamServerSideEncryptionOutputReference;
+    putServerSideEncryption(value: KinesisFirehoseDeliveryStreamServerSideEncryption): void;
+    resetServerSideEncryption(): void;
+    get serverSideEncryptionInput(): KinesisFirehoseDeliveryStreamServerSideEncryption | undefined;
+    private _snowflakeConfiguration;
+    get snowflakeConfiguration(): KinesisFirehoseDeliveryStreamSnowflakeConfigurationOutputReference;
+    putSnowflakeConfiguration(value: KinesisFirehoseDeliveryStreamSnowflakeConfiguration): void;
+    resetSnowflakeConfiguration(): void;
+    get snowflakeConfigurationInput(): KinesisFirehoseDeliveryStreamSnowflakeConfiguration | undefined;
+    private _splunkConfiguration;
+    get splunkConfiguration(): KinesisFirehoseDeliveryStreamSplunkConfigurationOutputReference;
+    putSplunkConfiguration(value: KinesisFirehoseDeliveryStreamSplunkConfiguration): void;
+    resetSplunkConfiguration(): void;
+    get splunkConfigurationInput(): KinesisFirehoseDeliveryStreamSplunkConfiguration | undefined;
+    private _timeouts;
+    get timeouts(): KinesisFirehoseDeliveryStreamTimeoutsOutputReference;
+    putTimeouts(value: KinesisFirehoseDeliveryStreamTimeouts): void;
+    resetTimeouts(): void;
+    get timeoutsInput(): cdktf.IResolvable | KinesisFirehoseDeliveryStreamTimeouts | undefined;
+    protected synthesizeAttributes(): {
+        [name: string]: any;
+    };
+    protected synthesizeHclAttributes(): {
+        [name: string]: any;
+    };
+}

--- a/data/reference/merged/provider-aws/rds-cluster-instance/index.d.ts
+++ b/data/reference/merged/provider-aws/rds-cluster-instance/index.d.ts
@@ -29,12 +29,7 @@ export interface RdsClusterInstanceConfig extends cdktf.TerraformMetaArguments {
     readonly engineVersion?: string;
     /** (Optional) Forces an instance to be destroyed when a part of a read replica cluster. **Note:** will promote the read replica to a standalone cluster before instance deletion. */
     readonly forceDestroy?: boolean | cdktf.IResolvable;
-    /**
-    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.93.0/docs/resources/rds_cluster_instance#id RdsClusterInstance#id}
-    *
-    * Please be aware that the id field is automatically added to all resources in Terraform providers using a Terraform provider SDK version below 2.
-    * If you experience problems setting this value it might not be settable. Please take a look at the provider documentation to ensure it should be settable.
-    */
+    /** */
     readonly id?: string;
     /** (Optional, Forces new resource) Identifier for the RDS instance, if omitted, Terraform will assign a random, unique identifier. */
     readonly identifier?: string;
@@ -64,17 +59,11 @@ export interface RdsClusterInstanceConfig extends cdktf.TerraformMetaArguments {
     readonly tags?: {
         [key: string]: string;
     };
-    /**
-    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.93.0/docs/resources/rds_cluster_instance#tags_all RdsClusterInstance#tags_all}
-    */
+    /** */
     readonly tagsAll?: {
         [key: string]: string;
     };
-    /**
-    * timeouts block
-    *
-    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.93.0/docs/resources/rds_cluster_instance#timeouts RdsClusterInstance#timeouts}
-    */
+    /** */
     readonly timeouts?: RdsClusterInstanceTimeouts;
 }
 export interface RdsClusterInstanceTimeouts {
@@ -114,7 +103,7 @@ export declare class RdsClusterInstanceTimeoutsOutputReference extends cdktf.Com
     get updateInput(): string | undefined;
 }
 /**
-* Represents a {@link https://registry.terraform.io/providers/hashicorp/aws/5.93.0/docs/resources/rds_cluster_instance aws_rds_cluster_instance}
+* Represents a {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/rds_cluster_instance aws_rds_cluster_instance}
 */
 export declare class RdsClusterInstance extends cdktf.TerraformResource {
     static readonly tfResourceType = "aws_rds_cluster_instance";
@@ -122,12 +111,12 @@ export declare class RdsClusterInstance extends cdktf.TerraformResource {
     * Generates CDKTF code for importing a RdsClusterInstance resource upon running "cdktf plan <stack-name>"
     * @param scope The scope in which to define this construct
     * @param importToId The construct id used in the generated config for the RdsClusterInstance to import
-    * @param importFromId The id of the existing RdsClusterInstance that should be imported. Refer to the {@link https://registry.terraform.io/providers/hashicorp/aws/5.93.0/docs/resources/rds_cluster_instance#import import section} in the documentation of this resource for the id to use
+    * @param importFromId The id of the existing RdsClusterInstance that should be imported. Refer to the {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/rds_cluster_instance#import import section} in the documentation of this resource for the id to use
     * @param provider? Optional instance of the provider where the RdsClusterInstance to import is found
     */
     static generateConfigForImport(scope: Construct, importToId: string, importFromId: string, provider?: cdktf.TerraformProvider): cdktf.ImportableResource;
     /**
-    * Create a new {@link https://registry.terraform.io/providers/hashicorp/aws/5.93.0/docs/resources/rds_cluster_instance aws_rds_cluster_instance} Resource
+    * Create a new {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/rds_cluster_instance aws_rds_cluster_instance} Resource
     *
     * @param scope The scope in which to define this construct
     * @param id The scoped construct ID. Must be unique amongst siblings in the same scope

--- a/data/reference/merged/provider-aws/rds-cluster-parameter-group/index.d.ts
+++ b/data/reference/merged/provider-aws/rds-cluster-parameter-group/index.d.ts
@@ -9,12 +9,7 @@ export interface RdsClusterParameterGroupConfig extends cdktf.TerraformMetaArgum
     readonly description?: string;
     /** (Required) The family of the DB cluster parameter group. */
     readonly family: string;
-    /**
-    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.93.0/docs/resources/rds_cluster_parameter_group#id RdsClusterParameterGroup#id}
-    *
-    * Please be aware that the id field is automatically added to all resources in Terraform providers using a Terraform provider SDK version below 2.
-    * If you experience problems setting this value it might not be settable. Please take a look at the provider documentation to ensure it should be settable.
-    */
+    /** */
     readonly id?: string;
     /** (Optional, Forces new resource) The name of the DB cluster parameter group. If omitted, Terraform will assign a random, unique name. */
     readonly name?: string;
@@ -24,19 +19,17 @@ export interface RdsClusterParameterGroupConfig extends cdktf.TerraformMetaArgum
     readonly tags?: {
         [key: string]: string;
     };
-    /**
-    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.93.0/docs/resources/rds_cluster_parameter_group#tags_all RdsClusterParameterGroup#tags_all}
-    */
+    /** */
     readonly tagsAll?: {
         [key: string]: string;
     };
-    /** (Optional) A list of DB parameters to apply. Note that parameters may differ from a family to an other. Full list of all parameters can be discovered via [`aws rds describe-db-cluster-parameters`](https://docs.aws.amazon.com/cli/latest/reference/rds/describe-db-cluster-parameters.html) after initial creation of the group. */
+    /** */
     readonly parameter?: RdsClusterParameterGroupParameter[] | cdktf.IResolvable;
 }
 export interface RdsClusterParameterGroupParameter {
     /** (Optional) "immediate" (default), or "pending-reboot". Some engines can't apply some parameters without a reboot, and you will need to specify "pending-reboot" here. */
     readonly applyMethod?: string;
-    /** (Optional, Forces new resource) The name of the DB cluster parameter group. If omitted, Terraform will assign a random, unique name. */
+    /** (Required) The name of the DB parameter. */
     readonly name: string;
     /** (Required) The value of the DB parameter. */
     readonly value: string;
@@ -86,7 +79,7 @@ export declare class RdsClusterParameterGroupParameterList extends cdktf.Complex
     get(index: number): RdsClusterParameterGroupParameterOutputReference;
 }
 /**
-* Represents a {@link https://registry.terraform.io/providers/hashicorp/aws/5.93.0/docs/resources/rds_cluster_parameter_group aws_rds_cluster_parameter_group}
+* Represents a {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/rds_cluster_parameter_group aws_rds_cluster_parameter_group}
 */
 export declare class RdsClusterParameterGroup extends cdktf.TerraformResource {
     static readonly tfResourceType = "aws_rds_cluster_parameter_group";
@@ -94,12 +87,12 @@ export declare class RdsClusterParameterGroup extends cdktf.TerraformResource {
     * Generates CDKTF code for importing a RdsClusterParameterGroup resource upon running "cdktf plan <stack-name>"
     * @param scope The scope in which to define this construct
     * @param importToId The construct id used in the generated config for the RdsClusterParameterGroup to import
-    * @param importFromId The id of the existing RdsClusterParameterGroup that should be imported. Refer to the {@link https://registry.terraform.io/providers/hashicorp/aws/5.93.0/docs/resources/rds_cluster_parameter_group#import import section} in the documentation of this resource for the id to use
+    * @param importFromId The id of the existing RdsClusterParameterGroup that should be imported. Refer to the {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/rds_cluster_parameter_group#import import section} in the documentation of this resource for the id to use
     * @param provider? Optional instance of the provider where the RdsClusterParameterGroup to import is found
     */
     static generateConfigForImport(scope: Construct, importToId: string, importFromId: string, provider?: cdktf.TerraformProvider): cdktf.ImportableResource;
     /**
-    * Create a new {@link https://registry.terraform.io/providers/hashicorp/aws/5.93.0/docs/resources/rds_cluster_parameter_group aws_rds_cluster_parameter_group} Resource
+    * Create a new {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/rds_cluster_parameter_group aws_rds_cluster_parameter_group} Resource
     *
     * @param scope The scope in which to define this construct
     * @param id The scoped construct ID. Must be unique amongst siblings in the same scope

--- a/data/reference/merged/provider-aws/rds-cluster-role-association/index.d.ts
+++ b/data/reference/merged/provider-aws/rds-cluster-role-association/index.d.ts
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+import { Construct } from 'constructs';
+import * as cdktf from 'cdktf';
+export interface RdsClusterRoleAssociationConfig extends cdktf.TerraformMetaArguments {
+    /** (Required) DB Cluster Identifier to associate with the IAM Role. */
+    readonly dbClusterIdentifier: string;
+    /** (Required) Name of the feature for association. This can be found in the AWS documentation relevant to the integration or a full list is available in the `SupportedFeatureNames` list returned by [AWS CLI rds describe-db-engine-versions](https://docs.aws.amazon.com/cli/latest/reference/rds/describe-db-engine-versions.html). */
+    readonly featureName: string;
+    /** */
+    readonly id?: string;
+    /** (Required) Amazon Resource Name (ARN) of the IAM Role to associate with the DB Cluster. */
+    readonly roleArn: string;
+    /** */
+    readonly timeouts?: RdsClusterRoleAssociationTimeouts;
+}
+export interface RdsClusterRoleAssociationTimeouts {
+    /** (Default `10m`) - `delete` - (Default `10m`) */
+    readonly create?: string;
+    /** (Default `10m`) */
+    readonly delete?: string;
+}
+export declare function rdsClusterRoleAssociationTimeoutsToTerraform(struct?: RdsClusterRoleAssociationTimeouts | cdktf.IResolvable): any;
+export declare function rdsClusterRoleAssociationTimeoutsToHclTerraform(struct?: RdsClusterRoleAssociationTimeouts | cdktf.IResolvable): any;
+export declare class RdsClusterRoleAssociationTimeoutsOutputReference extends cdktf.ComplexObject {
+    private isEmptyObject;
+    private resolvableValue?;
+    /**
+    * @param terraformResource The parent resource
+    * @param terraformAttribute The attribute on the parent resource this class is referencing
+    */
+    constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string);
+    get internalValue(): RdsClusterRoleAssociationTimeouts | cdktf.IResolvable | undefined;
+    set internalValue(value: RdsClusterRoleAssociationTimeouts | cdktf.IResolvable | undefined);
+    private _create?;
+    get create(): string;
+    set create(value: string);
+    resetCreate(): void;
+    get createInput(): string | undefined;
+    private _delete?;
+    get delete(): string;
+    set delete(value: string);
+    resetDelete(): void;
+    get deleteInput(): string | undefined;
+}
+/**
+* Represents a {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/rds_cluster_role_association aws_rds_cluster_role_association}
+*/
+export declare class RdsClusterRoleAssociation extends cdktf.TerraformResource {
+    static readonly tfResourceType = "aws_rds_cluster_role_association";
+    /**
+    * Generates CDKTF code for importing a RdsClusterRoleAssociation resource upon running "cdktf plan <stack-name>"
+    * @param scope The scope in which to define this construct
+    * @param importToId The construct id used in the generated config for the RdsClusterRoleAssociation to import
+    * @param importFromId The id of the existing RdsClusterRoleAssociation that should be imported. Refer to the {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/rds_cluster_role_association#import import section} in the documentation of this resource for the id to use
+    * @param provider? Optional instance of the provider where the RdsClusterRoleAssociation to import is found
+    */
+    static generateConfigForImport(scope: Construct, importToId: string, importFromId: string, provider?: cdktf.TerraformProvider): cdktf.ImportableResource;
+    /**
+    * Create a new {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/rds_cluster_role_association aws_rds_cluster_role_association} Resource
+    *
+    * @param scope The scope in which to define this construct
+    * @param id The scoped construct ID. Must be unique amongst siblings in the same scope
+    * @param options RdsClusterRoleAssociationConfig
+    */
+    constructor(scope: Construct, id: string, config: RdsClusterRoleAssociationConfig);
+    private _dbClusterIdentifier?;
+    get dbClusterIdentifier(): string;
+    set dbClusterIdentifier(value: string);
+    get dbClusterIdentifierInput(): string | undefined;
+    private _featureName?;
+    get featureName(): string;
+    set featureName(value: string);
+    get featureNameInput(): string | undefined;
+    private _id?;
+    get id(): string;
+    set id(value: string);
+    resetId(): void;
+    get idInput(): string | undefined;
+    private _roleArn?;
+    get roleArn(): string;
+    set roleArn(value: string);
+    get roleArnInput(): string | undefined;
+    private _timeouts;
+    get timeouts(): RdsClusterRoleAssociationTimeoutsOutputReference;
+    putTimeouts(value: RdsClusterRoleAssociationTimeouts): void;
+    resetTimeouts(): void;
+    get timeoutsInput(): cdktf.IResolvable | RdsClusterRoleAssociationTimeouts | undefined;
+    protected synthesizeAttributes(): {
+        [name: string]: any;
+    };
+    protected synthesizeHclAttributes(): {
+        [name: string]: any;
+    };
+}

--- a/data/reference/merged/provider-aws/rds-cluster/index.d.ts
+++ b/data/reference/merged/provider-aws/rds-cluster/index.d.ts
@@ -23,19 +23,13 @@ export interface RdsClusterConfig extends cdktf.TerraformMetaArguments {
     readonly clusterIdentifier?: string;
     /** (Optional, Forces new resource) Creates a unique cluster identifier beginning with the specified prefix. Conflicts with `clusterIdentifier`. */
     readonly clusterIdentifierPrefix?: string;
-    /**
-    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.93.0/docs/resources/rds_cluster#cluster_members RdsCluster#cluster_members}
-    */
+    /** */
     readonly clusterMembers?: string[];
-    /**
-    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.93.0/docs/resources/rds_cluster#cluster_scalability_type RdsCluster#cluster_scalability_type}
-    */
+    /** (Optional, Forces new resources) Specifies the scalability mode of the Aurora DB cluster. When set to `limitless`, the cluster operates as an Aurora Limitless Database. When set to `standard` (the default), the cluster uses normal DB instance creation. Valid values: `limitless`, `standard`. */
     readonly clusterScalabilityType?: string;
     /** (Optional, boolean) Copy all Cluster `tags` to snapshots. Default is `false`. */
     readonly copyTagsToSnapshot?: boolean | cdktf.IResolvable;
-    /**
-    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.93.0/docs/resources/rds_cluster#database_insights_mode RdsCluster#database_insights_mode}
-    */
+    /** (Optional) The mode of Database Insights to enable for the DB cluster. Valid values: `standard`, `advanced`. */
     readonly databaseInsightsMode?: string;
     /** (Optional) Name for an automatically created database on cluster creation. There are different naming restrictions per database engine: [RDS Naming Constraints][5] */
     readonly databaseName?: string;
@@ -69,7 +63,7 @@ export interface RdsClusterConfig extends cdktf.TerraformMetaArguments {
     readonly engine: string;
     /** (Optional) The life cycle type for this DB instance. This setting is valid for cluster types Aurora DB clusters and Multi-AZ DB clusters. Valid values are `open-source-rds-extended-support`, `open-source-rds-extended-support-disabled`. Default value is `open-source-rds-extended-support`. [Using Amazon RDS Extended Support]: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/extended-support.html */
     readonly engineLifecycleSupport?: string;
-    /** (Optional) Database engine mode. Valid values: `global` (only valid for Aurora MySQL 1.21 and earlier), `parallelquery`, `provisioned`, `serverless`. Defaults to: `provisioned`. See the [RDS User Guide](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless.html) for limitations when using `serverless`. */
+    /** (Optional) Database engine mode. Valid values: `global` (only valid for Aurora MySQL 1.21 and earlier), `parallelquery`, `provisioned`, `serverless`. Defaults to: `provisioned`. Specify an empty value (`""`) for no engine mode. See the [RDS User Guide](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless.html) for limitations when using `serverless`. */
     readonly engineMode?: string;
     /** (Optional) Database engine version. Updating this argument results in an outage. See the [Aurora MySQL](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Updates.html) and [Aurora Postgres](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Updates.html) documentation for your configured engine to determine this value, or by running `aws rds describe-db-engine-versions`. For example with Aurora MySQL 2, a potential value for this argument is `5.7.mysql_aurora.2.03.2`. The value can contain a partial version where supported by the API. The actual engine version used is returned in the attribute `engineVersionActual`, , see [Attribute Reference](#attribute-reference) below. */
     readonly engineVersion?: string;
@@ -81,12 +75,7 @@ export interface RdsClusterConfig extends cdktf.TerraformMetaArguments {
     readonly iamDatabaseAuthenticationEnabled?: boolean | cdktf.IResolvable;
     /** (Optional) List of ARNs for the IAM roles to associate to the RDS Cluster. */
     readonly iamRoles?: string[];
-    /**
-    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.93.0/docs/resources/rds_cluster#id RdsCluster#id}
-    *
-    * Please be aware that the id field is automatically added to all resources in Terraform providers using a Terraform provider SDK version below 2.
-    * If you experience problems setting this value it might not be settable. Please take a look at the provider documentation to ensure it should be settable.
-    */
+    /** */
     readonly id?: string;
     /** (Optional) Amount of Provisioned IOPS (input/output operations per second) to be initially allocated for each DB instance in the Multi-AZ DB cluster. For information about valid Iops values, see [Amazon RDS Provisioned IOPS storage to improve performance](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Storage.html#USER_PIOPS) in the Amazon RDS User Guide. (This setting is required to create a Multi-AZ DB cluster). Must be a multiple between .5 and 50 of the storage amount for the DB cluster. */
     readonly iops?: number;
@@ -94,15 +83,11 @@ export interface RdsClusterConfig extends cdktf.TerraformMetaArguments {
     readonly kmsKeyId?: string;
     /** (Optional) Set to true to allow RDS to manage the master user password in Secrets Manager. Cannot be set if `masterPassword` is provided. */
     readonly manageMasterUserPassword?: boolean | cdktf.IResolvable;
-    /** (Required unless `manageMasterUserPassword` is set to true or unless a `snapshotIdentifier` or `replicationSourceIdentifier` is provided or unless a `globalClusterIdentifier` is provided when the cluster is the "secondary" cluster of a global database) Password for the master DB user. Note that this may show up in logs, and it will be stored in the state file. Please refer to the [RDS Naming Constraints][5]. Cannot be set if `manageMasterUserPassword` is set to `true`. */
+    /** (Optional, required unless `manageMasterUserPassword` is set to true, a `snapshotIdentifier`, `replicationSourceIdentifier`, or `masterPasswordWo` is provided or unless a `globalClusterIdentifier` is provided when the cluster is the "secondary" cluster of a global database) Password for the master DB user. Note that this may show up in logs, and it will be stored in the state file. Please refer to the [RDS Naming Constraints][5]. Cannot be set if `manageMasterUserPassword` is set to `true`. */
     readonly masterPassword?: string;
-    /**
-    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.93.0/docs/resources/rds_cluster#master_password_wo RdsCluster#master_password_wo}
-    */
+    /** */
     readonly masterPasswordWo?: string;
-    /**
-    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.93.0/docs/resources/rds_cluster#master_password_wo_version RdsCluster#master_password_wo_version}
-    */
+    /** (Optional) Used together with `masterPasswordWo` to trigger an update. Increment this value when an update to the `masterPasswordWo` is required. */
     readonly masterPasswordWoVersion?: number;
     /** (Optional) Amazon Web Services KMS key identifier is the key ARN, key ID, alias ARN, or alias name for the KMS key. To use a KMS key in a different Amazon Web Services account, specify the key ARN or alias ARN. If not specified, the default KMS key for your Amazon Web Services account is used. */
     readonly masterUserSecretKmsKeyId?: string;
@@ -142,31 +127,21 @@ export interface RdsClusterConfig extends cdktf.TerraformMetaArguments {
     readonly tags?: {
         [key: string]: string;
     };
-    /**
-    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.93.0/docs/resources/rds_cluster#tags_all RdsCluster#tags_all}
-    */
+    /** */
     readonly tagsAll?: {
         [key: string]: string;
     };
-    /** (Optional) List of VPC security groups to associate with the Cluster */
+    /** (Optional) List of VPC security groups to associate with the Cluster For more detailed documentation about each argument, refer to the AWS official documentation: */
     readonly vpcSecurityGroupIds?: string[];
-    /** (Optional) Nested attribute for [point in time restore](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-pitr.html). More details below. */
+    /** */
     readonly restoreToPointInTime?: RdsClusterRestoreToPointInTime;
-    /**
-    * s3_import block
-    *
-    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.93.0/docs/resources/rds_cluster#s3_import RdsCluster#s3_import}
-    */
+    /** */
     readonly s3Import?: RdsClusterS3Import;
-    /** (Optional) Nested attribute with scaling properties. Only valid when `engineMode` is set to `serverless`. More details below. */
+    /** */
     readonly scalingConfiguration?: RdsClusterScalingConfiguration;
-    /** (Optional) Nested attribute with scaling properties for ServerlessV2. Only valid when `engineMode` is set to `provisioned`. More details below. */
+    /** */
     readonly serverlessv2ScalingConfiguration?: RdsClusterServerlessv2ScalingConfiguration;
-    /**
-    * timeouts block
-    *
-    * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/5.93.0/docs/resources/rds_cluster#timeouts RdsCluster#timeouts}
-    */
+    /** */
     readonly timeouts?: RdsClusterTimeouts;
 }
 export interface RdsClusterMasterUserSecret {
@@ -354,11 +329,11 @@ export declare class RdsClusterScalingConfigurationOutputReference extends cdktf
     get timeoutActionInput(): string | undefined;
 }
 export interface RdsClusterServerlessv2ScalingConfiguration {
-    /** (Optional) Maximum capacity for an Aurora DB cluster in `serverless` DB engine mode. The maximum capacity must be greater than or equal to the minimum capacity. Valid Aurora MySQL capacity values are `1`, `2`, `4`, `8`, `16`, `32`, `64`, `128`, `256`. Valid Aurora PostgreSQL capacity values are (`2`, `4`, `8`, `16`, `32`, `64`, `192`, and `384`). Defaults to `16`. */
+    /** (Required) Maximum capacity for an Aurora DB cluster in `provisioned` DB engine mode. The maximum capacity must be greater than or equal to the minimum capacity. Valid capacity values are in a range of `0` up to `256` in steps of `0.5`. */
     readonly maxCapacity: number;
-    /** (Optional) Minimum capacity for an Aurora DB cluster in `serverless` DB engine mode. The minimum capacity must be lesser than or equal to the maximum capacity. Valid Aurora MySQL capacity values are `1`, `2`, `4`, `8`, `16`, `32`, `64`, `128`, `256`. Valid Aurora PostgreSQL capacity values are (`2`, `4`, `8`, `16`, `32`, `64`, `192`, and `384`). Defaults to `1`. */
+    /** (Required) Minimum capacity for an Aurora DB cluster in `provisioned` DB engine mode. The minimum capacity must be lesser than or equal to the maximum capacity. Valid capacity values are in a range of `0` up to `256` in steps of `0.5`. */
     readonly minCapacity: number;
-    /** (Optional) Time, in seconds, before an Aurora DB cluster in serverless mode is paused. Valid values are `300` through `86400`. Defaults to `300`. */
+    /** (Optional) Time, in seconds, before an Aurora DB cluster in `provisioned` DB engine mode is paused. Valid values are `300` through `86400`. */
     readonly secondsUntilAutoPause?: number;
 }
 export declare function rdsClusterServerlessv2ScalingConfigurationToTerraform(struct?: RdsClusterServerlessv2ScalingConfigurationOutputReference | RdsClusterServerlessv2ScalingConfiguration): any;
@@ -423,7 +398,7 @@ export declare class RdsClusterTimeoutsOutputReference extends cdktf.ComplexObje
     get updateInput(): string | undefined;
 }
 /**
-* Represents a {@link https://registry.terraform.io/providers/hashicorp/aws/5.93.0/docs/resources/rds_cluster aws_rds_cluster}
+* Represents a {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/rds_cluster aws_rds_cluster}
 */
 export declare class RdsCluster extends cdktf.TerraformResource {
     static readonly tfResourceType = "aws_rds_cluster";
@@ -431,12 +406,12 @@ export declare class RdsCluster extends cdktf.TerraformResource {
     * Generates CDKTF code for importing a RdsCluster resource upon running "cdktf plan <stack-name>"
     * @param scope The scope in which to define this construct
     * @param importToId The construct id used in the generated config for the RdsCluster to import
-    * @param importFromId The id of the existing RdsCluster that should be imported. Refer to the {@link https://registry.terraform.io/providers/hashicorp/aws/5.93.0/docs/resources/rds_cluster#import import section} in the documentation of this resource for the id to use
+    * @param importFromId The id of the existing RdsCluster that should be imported. Refer to the {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/rds_cluster#import import section} in the documentation of this resource for the id to use
     * @param provider? Optional instance of the provider where the RdsCluster to import is found
     */
     static generateConfigForImport(scope: Construct, importToId: string, importFromId: string, provider?: cdktf.TerraformProvider): cdktf.ImportableResource;
     /**
-    * Create a new {@link https://registry.terraform.io/providers/hashicorp/aws/5.93.0/docs/resources/rds_cluster aws_rds_cluster} Resource
+    * Create a new {@link https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/rds_cluster aws_rds_cluster} Resource
     *
     * @param scope The scope in which to define this construct
     * @param id The scoped construct ID. Must be unique amongst siblings in the same scope

--- a/data/scripts/tfdocs2json/grep_source.go
+++ b/data/scripts/tfdocs2json/grep_source.go
@@ -349,6 +349,7 @@ func extractDescriptionWithMapping(sourceStr string, attrInfo AttributeInfo, int
 		"`" + camelCaseName + "` –", // Em-dash with camelCase
 		"`" + camelCaseName + "`–",  // Em-dash with camelCase and missing spaces
 		"`" + camelCaseName + "`-",  // Hyphen with camelCase
+		"* `" + camelCaseName + "`",  // No Hyphen, just bullet point
 	}
 
 	foundDescriptions := make([]string, 0)
@@ -438,19 +439,19 @@ func extractDescriptionWithMapping(sourceStr string, attrInfo AttributeInfo, int
 	if len(foundDescriptions) > 0 {
 		// Deduplicate descriptions
 		foundDescriptions = deduplicateDescriptions(foundDescriptions)
-		
+
 		if len(foundDescriptions) == 1 {
 			// If only one description found, return it directly
 			return foundDescriptions[0]
 		}
-		
+
 		// Handle multiple descriptions based on mode
 		if mapCollector != nil {
 			// Map generation mode: collect this ambiguous mapping
 			mapCollector.AddMapping(attrInfo, foundDescriptions)
 			return foundDescriptions[0] // Return first one for now
 		}
-		
+
 		if mapFile != nil {
 			// Map usage mode: look up the selected description
 			if selectedDesc, found := mapFile.GetSelectedDescription(attrInfo.FullPath); found {
@@ -460,7 +461,7 @@ func extractDescriptionWithMapping(sourceStr string, attrInfo AttributeInfo, int
 			fmt.Fprintf(os.Stderr, "Warning: Attribute '%s' not found in map file, using first description\n", attrInfo.FullPath)
 			return foundDescriptions[0]
 		}
-		
+
 		if interactive {
 			return selectDescriptionInteractively(attrInfo, foundDescriptions)
 		} else {
@@ -483,14 +484,14 @@ func deduplicateDescriptions(descriptions []string) []string {
 	}
 	seen := make(map[string]bool)
 	result := make([]string, 0, len(descriptions))
-	
+
 	for _, desc := range descriptions {
 		if !seen[desc] {
 			seen[desc] = true
 			result = append(result, desc)
 		}
 	}
-	
+
 	return result
 }
 

--- a/data/scripts/tfdocs2json/kinesis_firehose_delivery_stream.yml
+++ b/data/scripts/tfdocs2json/kinesis_firehose_delivery_stream.yml
@@ -23,7 +23,7 @@ mappings:
         - (Optional) Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. The default value is 300 (5 minutes).
         - (Optional) Buffer incoming data for the specified period of time, in seconds between 0 to 900, before delivering it to the destination.  The default value is 0s.
         - (Optional) Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. The default value is 300.
-      selected_description: (Optional) Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. The default value is 300.
+      selected_description: (Optional) Buffer incoming data for the specified period of time, in seconds between 0 to 900, before delivering it to the destination.  The default value is 300s.
     - attribute_path: ElasticsearchConfiguration.bufferingSize
       camel_case_name: bufferingSize
       required: false
@@ -35,7 +35,7 @@ mappings:
         - (Optional) Buffer incoming data to the specified size, in MBs between 1 to 5, before delivering it to the destination.  The default value is 5MB.
         - (Optional) Buffer incoming data to the specified size, in MBs, before delivering it to the destination. The default value is 5.
         - (Optional) Buffer incoming data to the specified size, in MBs between 1 to 128, before delivering it to the destination.  The default value is 1MB.
-      selected_description: (Optional) Buffer incoming data to the specified size, in MBs, before delivering it to the destination. The default value is 5.
+      selected_description: (Optional) Buffer incoming data to the specified size, in MBs between 1 to 100, before delivering it to the destination.  The default value is 5MB.
     - attribute_path: ElasticsearchConfiguration.indexName
       camel_case_name: indexName
       required: true
@@ -238,7 +238,7 @@ mappings:
         - (Required) The ARN of the AWS credentials.
         - (Optional) The ARN of the role the stream assumes.
         - (Required) The role that Kinesis Data Firehose can use to access AWS Glue. This role must be in the same account you use for Kinesis Data Firehose. Cross-account roles aren't allowed.
-      selected_description: (Required) Kinesis Data Firehose uses this IAM role for all the permissions that the delivery stream needs. The pattern needs to be `arn:.*`.
+      selected_description: (Required) The ARN of the IAM role to be assumed by Firehose for calling the Amazon ES Configuration API and for indexing documents.  The IAM role must have permission for `DescribeElasticsearchDomain`, `DescribeElasticsearchDomains`, and `DescribeElasticsearchDomainConfig`.  The pattern needs to be `arn:.*`.
     - attribute_path: ExtendedS3Configuration.s3BackupMode
       camel_case_name: s3BackupMode
       required: false
@@ -250,7 +250,7 @@ mappings:
         - (Optional) Defines how documents should be delivered to Amazon S3.  Valid values are `FailedEventsOnly` and `AllEvents`.  Default value is `FailedEventsOnly`.
         - (Optional) Defines how documents should be delivered to Amazon S3.  Valid values are `FailedDataOnly` and `AllData`.  Default value is `FailedDataOnly`.
         - (Optional) The S3 backup mode.
-      selected_description: (Optional) The S3 backup mode.
+      selected_description: (Optional) Defines how documents should be delivered to Amazon S3.  Valid values are `FailedDocumentsOnly` and `AllDocuments`.  Default value is `FailedDocumentsOnly`.
     - attribute_path: ExtendedS3Configuration.bufferingInterval
       camel_case_name: bufferingInterval
       required: false
@@ -263,7 +263,7 @@ mappings:
         - (Optional) Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. The default value is 300 (5 minutes).
         - (Optional) Buffer incoming data for the specified period of time, in seconds between 0 to 900, before delivering it to the destination.  The default value is 0s.
         - (Optional) Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. The default value is 300.
-      selected_description: (Optional) Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. The default value is 300 (5 minutes).
+      selected_description: (Optional) Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. The default value is 300.
     - attribute_path: ExtendedS3Configuration.bufferingSize
       camel_case_name: bufferingSize
       required: false
@@ -312,7 +312,7 @@ mappings:
       available_descriptions:
         - (Optional) The compression code to use over data blocks. The default is `SNAPPY`.
         - (Optional) The compression code to use over data blocks. The possible values are `UNCOMPRESSED`, `SNAPPY`, and `GZIP`, with the default being `SNAPPY`. Use `SNAPPY` for higher decompression speed. Use `GZIP` if the compression ratio is more important than speed.
-      selected_description: (Optional) The compression code to use over data blocks. The possible values are `UNCOMPRESSED`, `SNAPPY`, and `GZIP`, with the default being `SNAPPY`. Use `SNAPPY` for higher decompression speed. Use `GZIP` if the compression ratio is more important than speed.
+      selected_description: (Optional) The compression code to use over data blocks. The default is `SNAPPY`.
     - attribute_path: ExtendedS3ConfigurationDataFormatConversionConfigurationOutputFormatConfigurationSerializerParquetSerDe.compression
       camel_case_name: compression
       required: false
@@ -373,7 +373,7 @@ mappings:
         - (Optional) Defaults to `true`. Set it to `false` if you want to disable format conversion while preserving the configuration details.
         - (Optional) Enables or disables the Secrets Manager configuration.
         - (Optional) Enables or disables dynamic partitioning. Defaults to `false`.
-      selected_description: (Optional) Enables or disables dynamic partitioning. Defaults to `false`.
+      selected_description: (Optional) Enables or disables dynamic partitioning. Defaults to `false`. **NOTE:** You can enable dynamic partitioning only when you create a new delivery stream. Once you enable dynamic partitioning on a delivery stream, it cannot be disabled on this delivery stream. Therefore, Terraform will recreate the resource whenever dynamic partitioning is enabled or disabled.
     - attribute_path: ExtendedS3ConfigurationDynamicPartitioningConfiguration.retryDuration
       camel_case_name: retryDuration
       required: false
@@ -389,7 +389,7 @@ mappings:
         - (Optional) Total amount of seconds Firehose spends on retries. This duration starts after the initial attempt fails, It does not include the time periods during which Firehose waits for acknowledgment from the specified destination after each attempt. Valid values between `0` and `7200`. Default is `300`.
         - (Optional) After an initial failure to deliver to Snowflake, the total amount of time, in seconds between 0 to 7200, during which Firehose re-attempts delivery (including the first attempt).  After this time has elapsed, the failed documents are written to Amazon S3.  The default value is 60s.  There will be no retry if the value is 0.
         - (Optional) Total amount of seconds Firehose spends on retries. Valid values between 0 and 7200. Default is 300.
-      selected_description: (Optional) Total amount of seconds Firehose spends on retries. This duration starts after the initial attempt fails, It does not include the time periods during which Firehose waits for acknowledgment from the specified destination after each attempt. Valid values between `0` and `7200`. Default is `300`.
+      selected_description: (Optional) Total amount of seconds Firehose spends on retries. Valid values between 0 and 7200. Default is 300.
     - attribute_path: ExtendedS3ConfigurationProcessingConfiguration.enabled
       camel_case_name: enabled
       required: false
@@ -423,7 +423,7 @@ mappings:
         - (Required) The ARN of the AWS credentials.
         - (Optional) The ARN of the role the stream assumes.
         - (Required) The role that Kinesis Data Firehose can use to access AWS Glue. This role must be in the same account you use for Kinesis Data Firehose. Cross-account roles aren't allowed.
-      selected_description: (Required) Kinesis Data Firehose uses this IAM role for all the permissions that the delivery stream needs. The pattern needs to be `arn:.*`.
+      selected_description: (Required) The ARN of the AWS credentials.
     - attribute_path: ExtendedS3ConfigurationS3BackupConfiguration.bufferingInterval
       camel_case_name: bufferingInterval
       required: false
@@ -436,7 +436,7 @@ mappings:
         - (Optional) Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. The default value is 300 (5 minutes).
         - (Optional) Buffer incoming data for the specified period of time, in seconds between 0 to 900, before delivering it to the destination.  The default value is 0s.
         - (Optional) Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. The default value is 300.
-      selected_description: (Optional) Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. The default value is 300 (5 minutes).
+      selected_description: (Optional) Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. The default value is 300.
     - attribute_path: ExtendedS3ConfigurationS3BackupConfiguration.bufferingSize
       camel_case_name: bufferingSize
       required: false
@@ -487,7 +487,7 @@ mappings:
         - (Optional) Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. The default value is 300 (5 minutes).
         - (Optional) Buffer incoming data for the specified period of time, in seconds between 0 to 900, before delivering it to the destination.  The default value is 0s.
         - (Optional) Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. The default value is 300.
-      selected_description: (Optional) Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. The default value is 300.
+      selected_description: (Optional) Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. The default value is 300 (5 minutes).
     - attribute_path: HttpEndpointConfiguration.bufferingSize
       camel_case_name: bufferingSize
       required: false
@@ -545,7 +545,7 @@ mappings:
         - (Required) The ARN of the AWS credentials.
         - (Optional) The ARN of the role the stream assumes.
         - (Required) The role that Kinesis Data Firehose can use to access AWS Glue. This role must be in the same account you use for Kinesis Data Firehose. Cross-account roles aren't allowed.
-      selected_description: (Optional) The ARN of the role the stream assumes.
+      selected_description: (Required) Kinesis Data Firehose uses this IAM role for all the permissions that the delivery stream needs. The pattern needs to be `arn:.*`.
     - attribute_path: HttpEndpointConfigurationCloudwatchLoggingOptions.enabled
       camel_case_name: enabled
       required: false
@@ -603,7 +603,7 @@ mappings:
         - (Required) The ARN of the AWS credentials.
         - (Optional) The ARN of the role the stream assumes.
         - (Required) The role that Kinesis Data Firehose can use to access AWS Glue. This role must be in the same account you use for Kinesis Data Firehose. Cross-account roles aren't allowed.
-      selected_description: (Required) Kinesis Data Firehose uses this IAM role for all the permissions that the delivery stream needs. The pattern needs to be `arn:.*`.
+      selected_description: (Required) The ARN of the AWS credentials.
     - attribute_path: HttpEndpointConfigurationS3Configuration.bufferingInterval
       camel_case_name: bufferingInterval
       required: false
@@ -628,7 +628,7 @@ mappings:
         - (Optional) Buffer incoming data to the specified size, in MBs between 1 to 5, before delivering it to the destination.  The default value is 5MB.
         - (Optional) Buffer incoming data to the specified size, in MBs, before delivering it to the destination. The default value is 5.
         - (Optional) Buffer incoming data to the specified size, in MBs between 1 to 128, before delivering it to the destination.  The default value is 1MB.
-      selected_description: (Optional) Buffer incoming data to the specified size, in MBs, before delivering it to the destination. The default value is 5.
+      selected_description: (Optional) Buffer incoming data to the specified size, in MBs, before delivering it to the destination. The default value is 5. We recommend setting SizeInMBs to a value greater than the amount of data you typically ingest into the delivery stream in 10 seconds. For example, if you typically ingest data at 1 MB/sec set SizeInMBs to be 10 MB or higher.
     - attribute_path: HttpEndpointConfigurationS3ConfigurationCloudwatchLoggingOptions.enabled
       camel_case_name: enabled
       required: false
@@ -676,7 +676,7 @@ mappings:
         - (Required) The ARN of the AWS credentials.
         - (Optional) The ARN of the role the stream assumes.
         - (Required) The role that Kinesis Data Firehose can use to access AWS Glue. This role must be in the same account you use for Kinesis Data Firehose. Cross-account roles aren't allowed.
-      selected_description: (Optional) The ARN of the role the stream assumes.
+      selected_description: (Optional) The ARN of the Secrets Manager secret. This value is required if `enabled` is true.
     - attribute_path: IcebergConfiguration.roleArn
       camel_case_name: roleArn
       required: true
@@ -708,7 +708,7 @@ mappings:
         - (Optional) Defines how documents should be delivered to Amazon S3.  Valid values are `FailedEventsOnly` and `AllEvents`.  Default value is `FailedEventsOnly`.
         - (Optional) Defines how documents should be delivered to Amazon S3.  Valid values are `FailedDataOnly` and `AllData`.  Default value is `FailedDataOnly`.
         - (Optional) The S3 backup mode.
-      selected_description: (Optional) The S3 backup mode.
+      selected_description: (Optional) Defines how documents should be delivered to Amazon S3.  Valid values are `FailedDataOnly` and `AllData`.  Default value is `FailedDataOnly`.
     - attribute_path: IcebergConfiguration.bufferingInterval
       camel_case_name: bufferingInterval
       required: false
@@ -721,7 +721,7 @@ mappings:
         - (Optional) Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. The default value is 300 (5 minutes).
         - (Optional) Buffer incoming data for the specified period of time, in seconds between 0 to 900, before delivering it to the destination.  The default value is 0s.
         - (Optional) Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. The default value is 300.
-      selected_description: (Optional) Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. The default value is 300.
+      selected_description: (Optional) Buffer incoming data for the specified period of time, in seconds between 0 and 900, before delivering it to the destination. The default value is 300.
     - attribute_path: IcebergConfiguration.bufferingSize
       camel_case_name: bufferingSize
       required: false
@@ -733,7 +733,7 @@ mappings:
         - (Optional) Buffer incoming data to the specified size, in MBs between 1 to 5, before delivering it to the destination.  The default value is 5MB.
         - (Optional) Buffer incoming data to the specified size, in MBs, before delivering it to the destination. The default value is 5.
         - (Optional) Buffer incoming data to the specified size, in MBs between 1 to 128, before delivering it to the destination.  The default value is 1MB.
-      selected_description: (Optional) Buffer incoming data to the specified size, in MBs, before delivering it to the destination. The default value is 5.
+      selected_description: (Optional) Buffer incoming data to the specified size, in MBs between 1 and 128, before delivering it to the destination. The default value is 5.
     - attribute_path: IcebergConfiguration.retryDuration
       camel_case_name: retryDuration
       required: false
@@ -808,7 +808,7 @@ mappings:
         - (Optional) Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. The default value is 300 (5 minutes).
         - (Optional) Buffer incoming data for the specified period of time, in seconds between 0 to 900, before delivering it to the destination.  The default value is 0s.
         - (Optional) Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. The default value is 300.
-      selected_description: (Optional) Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. The default value is 300 (5 minutes).
+      selected_description: (Optional) Buffer incoming data for the specified period of time, in seconds between 0 and 900, before delivering it to the destination. The default value is 300. (5 minutes).
     - attribute_path: IcebergConfigurationS3Configuration.bufferingSize
       camel_case_name: bufferingSize
       required: false
@@ -820,7 +820,7 @@ mappings:
         - (Optional) Buffer incoming data to the specified size, in MBs between 1 to 5, before delivering it to the destination.  The default value is 5MB.
         - (Optional) Buffer incoming data to the specified size, in MBs, before delivering it to the destination. The default value is 5.
         - (Optional) Buffer incoming data to the specified size, in MBs between 1 to 128, before delivering it to the destination.  The default value is 1MB.
-      selected_description: (Optional) Buffer incoming data to the specified size, in MBs, before delivering it to the destination. The default value is 5.
+      selected_description: (Optional) Buffer incoming data to the specified size, in MBs between 1 and 128, before delivering it to the destination. The default value is 5.
     - attribute_path: IcebergConfigurationS3Configuration.roleArn
       camel_case_name: roleArn
       required: true
@@ -840,7 +840,7 @@ mappings:
         - (Required) The ARN of the AWS credentials.
         - (Optional) The ARN of the role the stream assumes.
         - (Required) The role that Kinesis Data Firehose can use to access AWS Glue. This role must be in the same account you use for Kinesis Data Firehose. Cross-account roles aren't allowed.
-      selected_description: (Required) Kinesis Data Firehose uses this IAM role for all the permissions that the delivery stream needs. The pattern needs to be `arn:.*`.
+      selected_description: (Required) The ARN of the IAM role to be assumed by Firehose for calling Apache Iceberg Tables.
     - attribute_path: IcebergConfigurationS3ConfigurationCloudwatchLoggingOptions.enabled
       camel_case_name: enabled
       required: false
@@ -907,7 +907,7 @@ mappings:
         - (Optional) Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. The default value is 300 (5 minutes).
         - (Optional) Buffer incoming data for the specified period of time, in seconds between 0 to 900, before delivering it to the destination.  The default value is 0s.
         - (Optional) Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. The default value is 300.
-      selected_description: (Optional) Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. The default value is 300.
+      selected_description: (Optional) Buffer incoming data for the specified period of time, in seconds between 0 to 900, before delivering it to the destination.  The default value is 300s.
     - attribute_path: OpensearchConfiguration.bufferingSize
       camel_case_name: bufferingSize
       required: false
@@ -919,7 +919,7 @@ mappings:
         - (Optional) Buffer incoming data to the specified size, in MBs between 1 to 5, before delivering it to the destination.  The default value is 5MB.
         - (Optional) Buffer incoming data to the specified size, in MBs, before delivering it to the destination. The default value is 5.
         - (Optional) Buffer incoming data to the specified size, in MBs between 1 to 128, before delivering it to the destination.  The default value is 1MB.
-      selected_description: (Optional) Buffer incoming data to the specified size, in MBs, before delivering it to the destination. The default value is 5.
+      selected_description: (Optional) Buffer incoming data to the specified size, in MBs between 1 to 100, before delivering it to the destination.  The default value is 5MB.
     - attribute_path: OpensearchConfiguration.indexName
       camel_case_name: indexName
       required: true
@@ -1068,7 +1068,7 @@ mappings:
         - (Required) The ARN of the AWS credentials.
         - (Optional) The ARN of the role the stream assumes.
         - (Required) The role that Kinesis Data Firehose can use to access AWS Glue. This role must be in the same account you use for Kinesis Data Firehose. Cross-account roles aren't allowed.
-      selected_description: (Required) Kinesis Data Firehose uses this IAM role for all the permissions that the delivery stream needs. The pattern needs to be `arn:.*`.
+      selected_description: (Required) The ARN of the AWS credentials.
     - attribute_path: OpensearchConfigurationS3ConfigurationCloudwatchLoggingOptions.enabled
       camel_case_name: enabled
       required: false
@@ -1147,7 +1147,7 @@ mappings:
         - (Optional) Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. The default value is 300 (5 minutes).
         - (Optional) Buffer incoming data for the specified period of time, in seconds between 0 to 900, before delivering it to the destination.  The default value is 0s.
         - (Optional) Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. The default value is 300.
-      selected_description: (Optional) Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. The default value is 300.
+      selected_description:  (Optional) Buffer incoming data for the specified period of time, in seconds between 0 to 900, before delivering it to the destination.  The default value is 300s.
     - attribute_path: OpensearchserverlessConfiguration.bufferingSize
       camel_case_name: bufferingSize
       required: false
@@ -1159,7 +1159,7 @@ mappings:
         - (Optional) Buffer incoming data to the specified size, in MBs between 1 to 5, before delivering it to the destination.  The default value is 5MB.
         - (Optional) Buffer incoming data to the specified size, in MBs, before delivering it to the destination. The default value is 5.
         - (Optional) Buffer incoming data to the specified size, in MBs between 1 to 128, before delivering it to the destination.  The default value is 1MB.
-      selected_description: (Optional) Buffer incoming data to the specified size, in MBs, before delivering it to the destination. The default value is 5.
+      selected_description: (Optional) Buffer incoming data to the specified size, in MBs between 1 to 100, before delivering it to the destination.  The default value is 5MB.
     - attribute_path: OpensearchserverlessConfiguration.indexName
       camel_case_name: indexName
       required: true
@@ -1233,7 +1233,7 @@ mappings:
         - (Required) The ARN of the AWS credentials.
         - (Optional) The ARN of the role the stream assumes.
         - (Required) The role that Kinesis Data Firehose can use to access AWS Glue. This role must be in the same account you use for Kinesis Data Firehose. Cross-account roles aren't allowed.
-      selected_description: (Required) Kinesis Data Firehose uses this IAM role for all the permissions that the delivery stream needs. The pattern needs to be `arn:.*`.
+      selected_description: (Required) The ARN of the AWS credentials.
     - attribute_path: OpensearchserverlessConfigurationS3Configuration.bufferingInterval
       camel_case_name: bufferingInterval
       required: false
@@ -1258,7 +1258,7 @@ mappings:
         - (Optional) Buffer incoming data to the specified size, in MBs between 1 to 5, before delivering it to the destination.  The default value is 5MB.
         - (Optional) Buffer incoming data to the specified size, in MBs, before delivering it to the destination. The default value is 5.
         - (Optional) Buffer incoming data to the specified size, in MBs between 1 to 128, before delivering it to the destination.  The default value is 1MB.
-      selected_description: (Optional) Buffer incoming data to the specified size, in MBs, before delivering it to the destination. The default value is 5.
+      selected_description: (Optional) Buffer incoming data to the specified size, in MBs, before delivering it to the destination. The default value is 5. We recommend setting SizeInMBs to a value greater than the amount of data you typically ingest into the delivery stream in 10 seconds. For example, if you typically ingest data at 1 MB/sec set SizeInMBs to be 10 MB or higher.
     - attribute_path: OpensearchserverlessConfigurationS3ConfigurationCloudwatchLoggingOptions.enabled
       camel_case_name: enabled
       required: false
@@ -1320,7 +1320,7 @@ mappings:
         - (Optional) Defines how documents should be delivered to Amazon S3.  Valid values are `FailedEventsOnly` and `AllEvents`.  Default value is `FailedEventsOnly`.
         - (Optional) Defines how documents should be delivered to Amazon S3.  Valid values are `FailedDataOnly` and `AllData`.  Default value is `FailedDataOnly`.
         - (Optional) The S3 backup mode.
-      selected_description: (Optional) The S3 backup mode.
+      selected_description: (Optional) The Amazon S3 backup mode.  Valid values are `Disabled` and `Enabled`.  Default value is `Disabled`.
     - attribute_path: RedshiftConfiguration.roleArn
       camel_case_name: roleArn
       required: true
@@ -1340,7 +1340,7 @@ mappings:
         - (Required) The ARN of the AWS credentials.
         - (Optional) The ARN of the role the stream assumes.
         - (Required) The role that Kinesis Data Firehose can use to access AWS Glue. This role must be in the same account you use for Kinesis Data Firehose. Cross-account roles aren't allowed.
-      selected_description: (Required) Kinesis Data Firehose uses this IAM role for all the permissions that the delivery stream needs. The pattern needs to be `arn:.*`.
+      selected_description: (Required) The arn of the role the stream assumes.
     - attribute_path: RedshiftConfigurationCloudwatchLoggingOptions.enabled
       camel_case_name: enabled
       required: false
@@ -1566,7 +1566,7 @@ mappings:
         - (Optional) Defines how documents should be delivered to Amazon S3.  Valid values are `FailedEventsOnly` and `AllEvents`.  Default value is `FailedEventsOnly`.
         - (Optional) Defines how documents should be delivered to Amazon S3.  Valid values are `FailedDataOnly` and `AllData`.  Default value is `FailedDataOnly`.
         - (Optional) The S3 backup mode.
-      selected_description: (Optional) The S3 backup mode.
+      selected_description: (Optional) Defines how documents should be delivered to Amazon S3.  Valid values are `FailedDataOnly` and `AllData`.  Default value is `FailedDataOnly`.
     - attribute_path: SnowflakeConfiguration.bufferingSize
       camel_case_name: bufferingSize
       required: false
@@ -1578,7 +1578,7 @@ mappings:
         - (Optional) Buffer incoming data to the specified size, in MBs between 1 to 5, before delivering it to the destination.  The default value is 5MB.
         - (Optional) Buffer incoming data to the specified size, in MBs, before delivering it to the destination. The default value is 5.
         - (Optional) Buffer incoming data to the specified size, in MBs between 1 to 128, before delivering it to the destination.  The default value is 1MB.
-      selected_description: (Optional) Buffer incoming data to the specified size, in MBs between 1 and 128, before delivering it to the destination. The default value is 5.
+      selected_description: (Optional) Buffer incoming data to the specified size, in MBs between 1 to 128, before delivering it to the destination.  The default value is 1MB.
     - attribute_path: SnowflakeConfiguration.retryDuration
       camel_case_name: retryDuration
       required: false
@@ -1607,7 +1607,7 @@ mappings:
         - (Optional) Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. The default value is 300 (5 minutes).
         - (Optional) Buffer incoming data for the specified period of time, in seconds between 0 to 900, before delivering it to the destination.  The default value is 0s.
         - (Optional) Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. The default value is 300.
-      selected_description: (Optional) Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. The default value is 300.
+      selected_description: (Optional) Buffer incoming data for the specified period of time, in seconds between 0 to 900, before delivering it to the destination. The default value is 0s.
     - attribute_path: SnowflakeConfigurationCloudwatchLoggingOptions.enabled
       camel_case_name: enabled
       required: false
@@ -1767,7 +1767,7 @@ mappings:
         - (Optional) Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. The default value is 300 (5 minutes).
         - (Optional) Buffer incoming data for the specified period of time, in seconds between 0 to 900, before delivering it to the destination.  The default value is 0s.
         - (Optional) Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. The default value is 300.
-      selected_description: (Optional) Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. The default value is 300.
+      selected_description: (Optional) Buffer incoming data for the specified period of time, in seconds between 0 to 60, before delivering it to the destination.  The default value is 60s.
     - attribute_path: SplunkConfiguration.bufferingSize
       camel_case_name: bufferingSize
       required: false
@@ -1779,7 +1779,7 @@ mappings:
         - (Optional) Buffer incoming data to the specified size, in MBs between 1 to 5, before delivering it to the destination.  The default value is 5MB.
         - (Optional) Buffer incoming data to the specified size, in MBs, before delivering it to the destination. The default value is 5.
         - (Optional) Buffer incoming data to the specified size, in MBs between 1 to 128, before delivering it to the destination.  The default value is 1MB.
-      selected_description: (Optional) Buffer incoming data to the specified size, in MBs, before delivering it to the destination. The default value is 5.
+      selected_description: (Optional) Buffer incoming data to the specified size, in MBs between 1 to 5, before delivering it to the destination.  The default value is 5MB.
     - attribute_path: SplunkConfiguration.retryDuration
       camel_case_name: retryDuration
       required: false


### PR DESCRIPTION
Some docs do not include a hyphen for argument bullet points.
